### PR TITLE
Add a new "test-style" Makefile target

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -372,16 +372,16 @@ func getDefaultConfigDir(confPath string) string {
 	return filepath.Join(homedir.Get(), confPath)
 }
 
-type DockerAuthConfigObsolete struct {
+type dockerAuthConfigObsolete struct {
 	Auth string `json:"auth"`
 }
 
-type DockerAuthConfig struct {
+type dockerAuthConfig struct {
 	Auth string `json:"auth,omitempty"`
 }
 
-type DockerConfigFile struct {
-	AuthConfigs map[string]DockerAuthConfig `json:"auths"`
+type dockerConfigFile struct {
+	AuthConfigs map[string]dockerAuthConfig `json:"auths"`
 }
 
 func decodeDockerAuth(s string) (string, string, error) {
@@ -408,7 +408,7 @@ func getAuth(hostname string) (string, string, error) {
 		if err != nil {
 			return "", "", err
 		}
-		var dockerAuth DockerConfigFile
+		var dockerAuth dockerConfigFile
 		if err := json.Unmarshal(j, &dockerAuth); err != nil {
 			return "", "", err
 		}
@@ -425,7 +425,7 @@ func getAuth(hostname string) (string, string, error) {
 		if err != nil {
 			return "", "", err
 		}
-		var dockerAuthOld map[string]DockerAuthConfigObsolete
+		var dockerAuthOld map[string]dockerAuthConfigObsolete
 		if err := json.Unmarshal(j, &dockerAuthOld); err != nil {
 			return "", "", err
 		}
@@ -440,7 +440,7 @@ func getAuth(hostname string) (string, string, error) {
 	return "", "", nil
 }
 
-type APIErr struct {
+type apiErr struct {
 	Code    string
 	Message string
 	Detail  interface{}
@@ -450,7 +450,7 @@ type pingResponse struct {
 	WWWAuthenticate string
 	APIVersion      string
 	scheme          string
-	errors          []APIErr
+	errors          []apiErr
 }
 
 func (pr *pingResponse) needsAuth() bool {
@@ -476,7 +476,7 @@ func ping(registry string) (*pingResponse, error) {
 		pr.scheme = scheme
 		if resp.StatusCode == http.StatusUnauthorized {
 			type APIErrors struct {
-				Errors []APIErr
+				Errors []apiErr
 			}
 			errs := &APIErrors{}
 			if err := json.NewDecoder(resp.Body).Decode(errs); err != nil {

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -372,16 +372,16 @@ func getDefaultConfigDir(confPath string) string {
 	return filepath.Join(homedir.Get(), confPath)
 }
 
-type DockerAuthConfigObsolete struct {
+type dockerAuthConfigObsolete struct {
 	Auth string `json:"auth"`
 }
 
-type DockerAuthConfig struct {
+type dockerAuthConfig struct {
 	Auth string `json:"auth,omitempty"`
 }
 
-type DockerConfigFile struct {
-	AuthConfigs map[string]DockerAuthConfig `json:"auths"`
+type dockerConfigFile struct {
+	AuthConfigs map[string]dockerAuthConfig `json:"auths"`
 }
 
 func decodeDockerAuth(s string) (string, string, error) {
@@ -408,7 +408,7 @@ func getAuth(hostname string) (string, string, error) {
 		if err != nil {
 			return "", "", err
 		}
-		var dockerAuth DockerConfigFile
+		var dockerAuth dockerConfigFile
 		if err := json.Unmarshal(j, &dockerAuth); err != nil {
 			return "", "", err
 		}
@@ -425,7 +425,7 @@ func getAuth(hostname string) (string, string, error) {
 		if err != nil {
 			return "", "", err
 		}
-		var dockerAuthOld map[string]DockerAuthConfigObsolete
+		var dockerAuthOld map[string]dockerAuthConfigObsolete
 		if err := json.Unmarshal(j, &dockerAuthOld); err != nil {
 			return "", "", err
 		}
@@ -440,7 +440,7 @@ func getAuth(hostname string) (string, string, error) {
 	return "", "", nil
 }
 
-type APIErr struct {
+type apiErr struct {
 	Code    string
 	Message string
 	Detail  interface{}
@@ -450,7 +450,7 @@ type pingResponse struct {
 	WWWAuthenticate string
 	APIVersion      string
 	scheme          string
-	errors          []APIErr
+	errors          []apiErr
 }
 
 func (pr *pingResponse) needsAuth() bool {
@@ -476,7 +476,7 @@ func ping(registry string) (*pingResponse, error) {
 		pr.scheme = scheme
 		if resp.StatusCode == http.StatusUnauthorized {
 			type APIErrors struct {
-				Errors []APIErr
+				Errors []apiErr
 			}
 			errs := &APIErrors{}
 			if err := json.NewDecoder(resp.Body).Decode(errs); err != nil {

--- a/docker/inspect/inspect.go
+++ b/docker/inspect/inspect.go
@@ -62,6 +62,7 @@ func validateName(name string) error {
 	return nil
 }
 
+// GetData retrieves an image manifest for a specified Docker reference.
 func GetData(c *cli.Context, name string) (types.ImageManifest, error) {
 	if err := validateName(name); err != nil {
 		return nil, err

--- a/docker/reference/reference.go
+++ b/docker/reference/reference.go
@@ -1,5 +1,4 @@
-// COPY FROM DOCKER/DOCKER
-package reference
+package reference // COPY FROM DOCKER/DOCKER
 
 import (
 	"errors"

--- a/types/types.go
+++ b/types/types.go
@@ -5,20 +5,24 @@ import (
 )
 
 const (
+	// DockerPrefix is the URL-like schema prefix used for Docker image references.
 	DockerPrefix = "docker://"
 )
 
+// Registry is a service providing repositories.
 type Registry interface {
 	Repositories() []Repository
 	Repository(ref string) Repository
 	Lookup(term string) []Image // docker registry v1 only AFAICT, v2 can be built hacking with Images()
 }
 
+// Repository is a set of images.
 type Repository interface {
 	Images() []Image
 	Image(ref string) Image // ref == image name w/o registry part
 }
 
+// Image is a Docker image in a repository.
 type Image interface {
 	// ref to repository?
 	Layers(layers ...string) error // configure download directory? Call it DownloadLayers?
@@ -27,11 +31,14 @@ type Image interface {
 	DockerTar() ([]byte, error) // ??? also, configure output directory
 }
 
+// ImageManifest is the interesting subset of metadata about an Image.
 // TODO(runcom)
 type ImageManifest interface {
 	Labels() map[string]string
 }
 
+// DockerImageManifest is a set of metadata describing Docker images and their manifest.json files.
+// Note that this is not exactly manifest.json, e.g. some fields have been added.
 type DockerImageManifest struct {
 	Tag             string
 	Digest          string
@@ -47,6 +54,7 @@ type DockerImageManifest struct {
 	Layers          []string // ???
 }
 
+// Labels returns labels attached to this image.
 func (m *DockerImageManifest) Labels() map[string]string {
 	return m.Config.Labels
 }

--- a/utils.go
+++ b/utils.go
@@ -7,6 +7,7 @@ import (
 	"github.com/projectatomic/skopeo/types"
 )
 
+// ParseImage converts image URL-like string to an initialized handler for that image.
 func ParseImage(img string) (types.Image, error) {
 	switch {
 	case strings.HasPrefix(img, types.DockerPrefix):

--- a/version.go
+++ b/version.go
@@ -1,5 +1,7 @@
 package skopeo
 
+// Version is a version of thils build.
 const Version = "0.1.12-dev"
 
+// GitCommit is a git commit hash of this build. It is ordinarily overriden by LDFLAGS in Makefile.
 var GitCommit = ""


### PR DESCRIPTION
I am not certain how the various `test-`* commands (with `test-local` to come) are best to be exposed and used, but at least having `Makefile` targets is better than fishing out the commands from my shell history.