### PR TITLE
Support for in-process command testing

### DIFF
--- a/cmd/skopeo/inspect.go
+++ b/cmd/skopeo/inspect.go
@@ -43,7 +43,7 @@ var inspectCmd = cli.Command{
 			return err
 		}
 		if c.Bool("raw") {
-			fmt.Println(string(rawManifest))
+			fmt.Fprintln(c.App.Writer, string(rawManifest))
 			return nil
 		}
 		imgInspect, err := img.Inspect()
@@ -77,7 +77,7 @@ var inspectCmd = cli.Command{
 		if err != nil {
 			return err
 		}
-		fmt.Println(string(out))
+		fmt.Fprintln(c.App.Writer, string(out))
 		return nil
 	},
 }

--- a/cmd/skopeo/main.go
+++ b/cmd/skopeo/main.go
@@ -17,7 +17,8 @@ const (
 	usage = `interact with registries`
 )
 
-func main() {
+// createApp returns a cli.App to be run or tested.
+func createApp() *cli.App {
 	app := cli.NewApp()
 	app.Name = "skopeo"
 	if gitCommit != "" {
@@ -67,6 +68,11 @@ func main() {
 		standaloneSignCmd,
 		standaloneVerifyCmd,
 	}
+	return app
+}
+
+func main() {
+	app := createApp()
 	if err := app.Run(os.Args); err != nil {
 		logrus.Fatal(err)
 	}

--- a/cmd/skopeo/main_test.go
+++ b/cmd/skopeo/main_test.go
@@ -1,0 +1,14 @@
+package main
+
+import "bytes"
+
+// runSkopeo creates an app object and runs it with args, with an implied first "skopeo".
+// Returns output intended for stdout and the returned error, if any.
+func runSkopeo(args ...string) (string, error) {
+	app := createApp()
+	stdout := bytes.Buffer{}
+	app.Writer = &stdout
+	args = append([]string{"skopeo"}, args...)
+	err := app.Run(args)
+	return stdout.String(), err
+}

--- a/cmd/skopeo/signing.go
+++ b/cmd/skopeo/signing.go
@@ -70,7 +70,6 @@ func standaloneVerify(context *cli.Context) error {
 
 	mech, err := signature.NewGPGSigningMechanism()
 	if err != nil {
-
 		return fmt.Errorf("Error initializing GPG: %v", err)
 	}
 	sig, err := signature.VerifyDockerManifestSignature(unverifiedSignature, unverifiedManifest, expectedDockerReference, mech, expectedFingerprint)
@@ -78,7 +77,7 @@ func standaloneVerify(context *cli.Context) error {
 		return fmt.Errorf("Error verifying signature: %v", err)
 	}
 
-	fmt.Printf("Signature verified, digest %s\n", sig.DockerManifestDigest)
+	fmt.Fprintf(context.App.Writer, "Signature verified, digest %s\n", sig.DockerManifestDigest)
 	return nil
 }
 


### PR DESCRIPTION
Instead of each command handler terminating the process, let it return
an error object, and terminate the process at the top level.

See https://github.com/mtrmac/skopeo/commit/3ccea6cdeaf7e375c50a907b7a709da2f184a5ae for usage.

This will need to be extended to also capture stdout/stderr.