### PR TITLE
Use contents of local checkout instead of last commit for validation

### DIFF
--- a/hack/make/.validate
+++ b/hack/make/.validate
@@ -21,9 +21,7 @@ if [ -z "$VALIDATE_UPSTREAM" ]; then
 	VALIDATE_COMMIT_DIFF="$VALIDATE_UPSTREAM...$VALIDATE_HEAD"
 	
 	validate_diff() {
-		if [ "$VALIDATE_UPSTREAM" != "$VALIDATE_HEAD" ]; then
-			git diff "$VALIDATE_COMMIT_DIFF" "$@"
-		fi
+		git diff "$VALIDATE_UPSTREAM" "$@"
 	}
 	validate_log() {
 		if [ "$VALIDATE_UPSTREAM" != "$VALIDATE_HEAD" ]; then

--- a/hack/make/validate-gofmt
+++ b/hack/make/validate-gofmt
@@ -8,8 +8,7 @@ unset IFS
 
 badFiles=()
 for f in "${files[@]}"; do
-	# we use "git show" here to validate that what's committed is formatted
-	if [ "$(git show "$VALIDATE_HEAD:$f" | gofmt -s -l)" ]; then
+	if [ "$(gofmt -s -l < $f)" ]; then
 		badFiles+=( "$f" )
 	fi
 done

--- a/hack/make/validate-lint
+++ b/hack/make/validate-lint
@@ -11,7 +11,6 @@ unset IFS
 
 errors=()
 for f in "${files[@]}"; do
-	# we use "git show" here to validate that what's committed passes go lint
 	failedLint=$(golint "$f")
 	if [ "$failedLint" ]; then
 		errors+=( "$failedLint" )

--- a/hack/make/validate-vet
+++ b/hack/make/validate-vet
@@ -8,7 +8,6 @@ unset IFS
 
 errors=()
 for f in "${files[@]}"; do
-	# we use "git show" here to validate that what's committed passes go vet
 	failedVet=$(go vet "$f")
 	if [ "$failedVet" ]; then
 		errors+=( "$failedVet" )


### PR DESCRIPTION
Validating only committed files is not useful in the natural
>  $test_everything_passes; commit; push

workflow; the failures will not be caught locally, only by Travis later (and only if PRs are used instead of direct commits to master).

So, use the working directory state instead of last commit for validations; and remove misleading comments in checks which already use the working directory state.