### PR TITLE
Add infrastructure for running unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,5 @@ notifications:
 
 script:
   - make validate
+  - make test-unit
   - make test-integration

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,4 @@ notifications:
   email: false
 
 script:
-  - make validate
-  - make test-unit
-  - make test-integration
+  - make check

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,8 @@ man:
 shell: build-container
 	$(DOCKER_RUN_DOCKER) bash
 
+check: validate test-unit test-integration
+
 test-integration: build-container
 	$(DOCKER_RUN_DOCKER) hack/make.sh test-integration
 
@@ -60,6 +62,12 @@ test-unit: build-container
 
 validate: build-container
 	$(DOCKER_RUN_DOCKER) hack/make.sh validate-git-marks validate-gofmt validate-lint validate-vet
+
+# This target is only intended for development, e.g. executing it from an IDE. Use (make test) for CI or pre-release testing. 
+test-all-local: validate-local test-unit-local
+
+validate-local:
+	hack/make.sh validate-git-marks validate-gofmt validate-lint validate-vet
 
 test-unit-local:
 	go test $$(go list -e ./... | grep -v '^github\.com/projectatomic/skopeo/\(integration\|vendor/.*\)$$')

--- a/Makefile
+++ b/Makefile
@@ -54,5 +54,12 @@ shell: build-container
 test-integration: build-container
 	$(DOCKER_RUN_DOCKER) hack/make.sh test-integration
 
+test-unit: build-container
+	# Just call (make test unit-local) here instead of worrying about environment differences, e.g. GO15VENDOREXPERIMENT.
+	$(DOCKER_RUN_DOCKER) make test-unit-local
+
 validate: build-container
 	$(DOCKER_RUN_DOCKER) hack/make.sh validate-git-marks validate-gofmt validate-lint validate-vet
+
+test-unit-local:
+	go test $$(go list -e ./... | grep -v '^github\.com/projectatomic/skopeo/\(integration\|vendor/.*\)$$')


### PR DESCRIPTION
There haven’t been any unit tests in the code base so far; after adding them,

- Just running them is more difficult than `go test .`, so `Makefile` targets are useful.
- A full test run (Docker,Travis,non-Docker) now means validate+unit+integration tests, and it is easy to forget one or more; so, this adds new all-in-one `Makefile` targets.
- Travis should run the unit tests; by using the all-in-one target we get this for free.
- IDEs should be able to run the tests; this adds a demo for VS Code

The VS Code aspect is honestly a bit dubious; I’ll gladly drop it if you think it does not belong upstream.