### PR TITLE
Add ImageSource and ImageDestination abstractions

### DIFF
--- a/directory.go
+++ b/directory.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/projectatomic/skopeo/types"
+)
+
+// manifestPath returns a path for the manifest within a directory using our conventions.
+func manifestPath(dir string) string {
+	return filepath.Join(dir, "manifest.json")
+}
+
+// manifestPath returns a path for a layer tarball within a directory using our conventions.
+func layerPath(dir string, digest string) string {
+	// FIXME: Should we keep the digest identification?
+	return filepath.Join(dir, strings.TrimPrefix(digest, "sha256:")+".tar")
+}
+
+// manifestPath returns a path for a signature within a directory using our conventions.
+func signaturePath(dir string, index int) string {
+	return filepath.Join(dir, fmt.Sprintf("signature-%d", index+1))
+}
+
+type dirImageDestination struct {
+	dir string
+}
+
+// NewDirImageDestination returns an ImageDestination for writing to an existing directory.
+func NewDirImageDestination(dir string) types.ImageDestination {
+	return &dirImageDestination{dir}
+}
+
+func (d *dirImageDestination) PutManifest(manifest []byte) error {
+	return ioutil.WriteFile(manifestPath(d.dir), manifest, 0644)
+}
+
+func (d *dirImageDestination) PutLayer(digest string, stream io.Reader) error {
+	layerFile, err := os.Create(layerPath(d.dir, digest))
+	if err != nil {
+		return err
+	}
+	defer layerFile.Close()
+	if _, err := io.Copy(layerFile, stream); err != nil {
+		return err
+	}
+	if err := layerFile.Sync(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (d *dirImageDestination) PutSignatures(signatures [][]byte) error {
+	for i, sig := range signatures {
+		if err := ioutil.WriteFile(signaturePath(d.dir, i), sig, 0644); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type dirImageSource struct {
+	dir string
+}
+
+// NewDirImageSource returns an ImageSource reading from an existing directory.
+func NewDirImageSource(dir string) types.ImageSource {
+	return &dirImageSource{dir}
+}
+
+func (s *dirImageSource) GetManifest() ([]byte, string, error) {
+	manifest, err := ioutil.ReadFile(manifestPath(s.dir))
+	if err != nil {
+		return nil, "", err
+	}
+
+	return manifest, "", nil // FIXME? unverifiedCanonicalDigest value - really primarily used by dockerImage
+}
+
+func (s *dirImageSource) GetLayer(digest string) (io.ReadCloser, error) {
+	return os.Open(layerPath(s.dir, digest))
+}
+
+func (s *dirImageSource) GetSignatures() ([][]byte, error) {
+	signatures := [][]byte{}
+	for i := 0; ; i++ {
+		signature, err := ioutil.ReadFile(signaturePath(s.dir, i))
+		if err != nil {
+			if os.IsNotExist(err) {
+				break
+			}
+			return nil, err
+		}
+		signatures = append(signatures, signature)
+	}
+	return signatures, nil
+}

--- a/types/types.go
+++ b/types/types.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"fmt"
+	"io"
 	"time"
 )
 
@@ -21,6 +22,20 @@ type Registry interface {
 type Repository interface {
 	Images() []Image
 	Image(ref string) Image // ref == image name w/o registry part
+}
+
+// ImageSource is a service, possibly remote (= slow), to download components of a single image.
+type ImageSource interface {
+	GetManifest() (manifest []byte, unverifiedCanonicalDigest string, err error)
+	GetLayer(digest string) (io.ReadCloser, error)
+	GetSignatures() ([][]byte, error)
+}
+
+// ImageDestination is a service, possibly remote (= slow), to store components of a single image.
+type ImageDestination interface {
+	PutManifest([]byte) error
+	PutLayer(digest string, stream io.Reader) error
+	PutSignatures(signatures [][]byte) error
 }
 
 // Image is a Docker image in a repository.


### PR DESCRIPTION
`docker.go` is currently doing everything related to Docker images. To better support the Docker Registry, Atomic Registry, `docker save,load}` tarballs, and local directories (for debugging) in the future, introduce `ImageSource` and `ImageDestination` as abstractions of dumb storage which does not modify its contents.

Currently the only implementations are the existing ones, Docker Registry `dockerImageSource` and a local directory (`dirImageSource`, `dirImageDestination`). The `dockerImage` struct remains, as a layer on top of `dockerImageSource`; eventually this should probably be restructured further (e.g. `dockerImage.Layers` should probably mostly happen in the top-level `layers.go`, so that we don’t hard-code creation of random-named directories in the current directory).