### PR TITLE
Cleanups

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -477,15 +477,16 @@ func newDockerImageSource(img, certPath string, tlsVerify bool) (*dockerImageSou
 		return nil, err
 	}
 	var tr *http.Transport
-	if certPath != "" {
+	if certPath != "" || !tlsVerify {
 		tlsc := &tls.Config{}
 
-		cert, err := tls.LoadX509KeyPair(filepath.Join(certPath, "cert.pem"), filepath.Join(certPath, "key.pem"))
-		if err != nil {
-			return nil, fmt.Errorf("Error loading x509 key pair: %s", err)
+		if certPath != "" {
+			cert, err := tls.LoadX509KeyPair(filepath.Join(certPath, "cert.pem"), filepath.Join(certPath, "key.pem"))
+			if err != nil {
+				return nil, fmt.Errorf("Error loading x509 key pair: %s", err)
+			}
+			tlsc.Certificates = append(tlsc.Certificates, cert)
 		}
-
-		tlsc.Certificates = append(tlsc.Certificates, cert)
 		tlsc.InsecureSkipVerify = !tlsVerify
 		tr = &http.Transport{
 			TLSClientConfig: tlsc,

--- a/docker.go
+++ b/docker.go
@@ -241,7 +241,7 @@ func (s *dockerImageSource) makeRequest(method, url string, headers map[string]s
 	}
 
 	url = fmt.Sprintf(baseURL, s.scheme, s.registry) + url
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest(method, url, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Do not merge now, as is this depends on and includes #29, filed mostly as a reminder to myself.

The cleanups are equally applicable to the non-#29 code, but the commits wouldn’t apply; after we deal with #29 I will rebase this manually one way or the other.