### PR TITLE
Test command output before eror status in signing integration tests

### DIFF
--- a/integration/signing_test.go
+++ b/integration/signing_test.go
@@ -107,11 +107,11 @@ func (s *SigningSuite) TestSignVerifySmoke(c *check.C) {
 	defer os.Remove(sigOutput.Name())
 	out, err := exec.Command(skopeoBinary, "standalone-sign", "-o", sigOutput.Name(),
 		manifestPath, dockerReference, s.fingerprint).CombinedOutput()
-	c.Assert(err, check.IsNil)
+	c.Assert(err, check.IsNil, check.Commentf("%s", out))
 	c.Assert(string(out), check.Equals, "")
 
 	out, err = exec.Command(skopeoBinary, "standalone-verify", manifestPath,
 		dockerReference, s.fingerprint, sigOutput.Name()).CombinedOutput()
-	c.Assert(err, check.IsNil)
+	c.Assert(err, check.IsNil, check.Commentf("%s", out))
 	c.Assert(string(out), check.Equals, "Signature verified, digest "+fixtures.TestImageManifestDigest+"\n")
 }


### PR DESCRIPTION
If executing the command fails, the output to stderr is more useful than
the exit code, so test the output first.