### PR TITLE
docker.go: do not concatenate url in ping

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -582,7 +582,8 @@ func (i *dockerImage) ping() (*pingResponse, error) {
 		client.Transport = i.transport
 	}
 	ping := func(scheme string) (*pingResponse, error) {
-		resp, err := client.Get(scheme + "://" + i.registry + "/v2/")
+		url := fmt.Sprintf(baseURL, scheme, i.registry)
+		resp, err := client.Get(url)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@redhat.com>