### PR TITLE
move libraries to pkgs

### DIFF
--- a/cmd/skopeo/inspect.go
+++ b/cmd/skopeo/inspect.go
@@ -18,20 +18,20 @@ var inspectCmd = cli.Command{
 		},
 	},
 	Action: func(c *cli.Context) {
-		img, err := parseImage(c)
+		img, err := parseImageSource(c, c.Args()[0])
 		if err != nil {
 			logrus.Fatal(err)
 		}
 		if c.Bool("raw") {
 			// TODO(runcom): hardcoded schema 2 version 1
-			b, err := img.RawManifest("2-1")
+			m, _, err := img.GetManifest()
 			if err != nil {
 				logrus.Fatal(err)
 			}
-			fmt.Println(string(b))
+			fmt.Println(string(m.Raw()))
 			return
 		}
-		imgInspect, err := img.Manifest()
+		imgInspect, _, err := img.GetManifest()
 		if err != nil {
 			logrus.Fatal(err)
 		}

--- a/cmd/skopeo/utils.go
+++ b/cmd/skopeo/utils.go
@@ -5,6 +5,9 @@ import (
 	"strings"
 
 	"github.com/codegangsta/cli"
+	"github.com/projectatomic/skopeo/directory"
+	"github.com/projectatomic/skopeo/docker"
+	"github.com/projectatomic/skopeo/openshift"
 	"github.com/projectatomic/skopeo/types"
 )
 
@@ -17,7 +20,7 @@ func parseImage(c *cli.Context) (types.Image, error) {
 	)
 	switch {
 	case strings.HasPrefix(imgName, types.DockerPrefix):
-		return parseDockerImage(strings.TrimPrefix(imgName, types.DockerPrefix), certPath, tlsVerify)
+		return docker.ParseDockerImage(strings.TrimPrefix(imgName, types.DockerPrefix), certPath, tlsVerify)
 		//case strings.HasPrefix(img, appcPrefix):
 		//
 	}
@@ -32,11 +35,11 @@ func parseImageSource(c *cli.Context, name string) (types.ImageSource, error) {
 	)
 	switch {
 	case strings.HasPrefix(name, types.DockerPrefix):
-		return NewDockerImageSource(strings.TrimPrefix(name, types.DockerPrefix), certPath, tlsVerify)
+		return docker.NewDockerImageSource(strings.TrimPrefix(name, types.DockerPrefix), certPath, tlsVerify)
 	case strings.HasPrefix(name, types.AtomicPrefix):
-		return NewOpenshiftImageSource(strings.TrimPrefix(name, types.AtomicPrefix), certPath, tlsVerify)
+		return openshift.NewOpenshiftImageSource(strings.TrimPrefix(name, types.AtomicPrefix), certPath, tlsVerify)
 	case strings.HasPrefix(name, types.DirectoryPrefix):
-		return NewDirImageSource(strings.TrimPrefix(name, types.DirectoryPrefix)), nil
+		return directory.NewDirImageSource(strings.TrimPrefix(name, types.DirectoryPrefix)), nil
 	}
 	return nil, fmt.Errorf("Unrecognized image reference %s", name)
 }
@@ -49,11 +52,11 @@ func parseImageDestination(c *cli.Context, name string) (types.ImageDestination,
 	)
 	switch {
 	case strings.HasPrefix(name, types.DockerPrefix):
-		return NewDockerImageDestination(strings.TrimPrefix(name, types.DockerPrefix), certPath, tlsVerify)
+		return docker.NewDockerImageDestination(strings.TrimPrefix(name, types.DockerPrefix), certPath, tlsVerify)
 	case strings.HasPrefix(name, types.AtomicPrefix):
-		return NewOpenshiftImageDestination(strings.TrimPrefix(name, types.AtomicPrefix), certPath, tlsVerify)
+		return openshift.NewOpenshiftImageDestination(strings.TrimPrefix(name, types.AtomicPrefix), certPath, tlsVerify)
 	case strings.HasPrefix(name, types.DirectoryPrefix):
-		return NewDirImageDestination(strings.TrimPrefix(name, types.DirectoryPrefix)), nil
+		return directory.NewDirImageDestination(strings.TrimPrefix(name, types.DirectoryPrefix)), nil
 	}
 	return nil, fmt.Errorf("Unrecognized image reference %s", name)
 }

--- a/directory/directory.go
+++ b/directory/directory.go
@@ -1,4 +1,4 @@
-package main
+package directory
 
 import (
 	"fmt"
@@ -77,13 +77,15 @@ func NewDirImageSource(dir string) types.ImageSource {
 	return &dirImageSource{dir}
 }
 
-func (s *dirImageSource) GetManifest() ([]byte, string, error) {
+func (s *dirImageSource) GetManifest() (types.ImageManifest, string, error) {
 	manifest, err := ioutil.ReadFile(manifestPath(s.dir))
 	if err != nil {
 		return nil, "", err
 	}
+	// TODO(runcom): we should hide this type from the pkg API
+	m := &types.DockerImageManifest{RawManifest: manifest}
 
-	return manifest, "", nil // FIXME? unverifiedCanonicalDigest value - really primarily used by dockerImage
+	return m, "", nil // FIXME? unverifiedCanonicalDigest value - really primarily used by dockerImage
 }
 
 func (s *dirImageSource) GetLayer(digest string) (io.ReadCloser, error) {

--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -1,4 +1,4 @@
-package main
+package docker
 
 import (
 	"crypto/tls"

--- a/docker/docker_image.go
+++ b/docker/docker_image.go
@@ -2,20 +2,13 @@ package docker
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"regexp"
 	"strings"
-	"time"
 
 	"github.com/projectatomic/skopeo/directory"
 	"github.com/projectatomic/skopeo/types"
-)
-
-var (
-	validHex = regexp.MustCompile(`^([a-f0-9]{64})$`)
 )
 
 type dockerImage struct {
@@ -83,57 +76,9 @@ type config struct {
 	Labels map[string]string
 }
 
-type v1Image struct {
-	// Config is the configuration of the container received from the client
-	Config *config `json:"config,omitempty"`
-	// DockerVersion specifies version on which image is built
-	DockerVersion string `json:"docker_version,omitempty"`
-	// Created timestamp when image was created
-	Created time.Time `json:"created"`
-	// Architecture is the hardware that the image is build and runs on
-	Architecture string `json:"architecture,omitempty"`
-	// OS is the operating system used to build and run the image
-	OS string `json:"os,omitempty"`
-}
-
 // TODO(runcom)
 func (i *dockerImage) DockerTar() ([]byte, error) {
 	return nil, nil
-}
-
-// will support v1 one day...
-type manifest interface {
-	String() string
-	GetLayers() []string
-}
-
-type manifestSchema1 struct {
-	Name     string
-	Tag      string
-	FSLayers []struct {
-		BlobSum string `json:"blobSum"`
-	} `json:"fsLayers"`
-	History []struct {
-		V1Compatibility string `json:"v1Compatibility"`
-	} `json:"history"`
-	// TODO(runcom) verify the downloaded manifest
-	//Signature []byte `json:"signature"`
-}
-
-func (m *manifestSchema1) GetLayers() []string {
-	layers := make([]string, len(m.FSLayers))
-	for i, layer := range m.FSLayers {
-		layers[i] = layer.BlobSum
-	}
-	return layers
-}
-
-func (m *manifestSchema1) String() string {
-	return fmt.Sprintf("%s-%s", sanitize(m.Name), sanitize(m.Tag))
-}
-
-func sanitize(s string) string {
-	return strings.Replace(s, "/", "-", -1)
 }
 
 func (i *dockerImage) retrieveRawManifest() error {
@@ -208,55 +153,4 @@ func (i *dockerImage) getLayer(dest types.ImageDestination, digest string) error
 	}
 	defer stream.Close()
 	return dest.PutLayer(digest, stream)
-}
-
-func fixManifestLayers(manifest *manifestSchema1) error {
-	type imageV1 struct {
-		ID     string
-		Parent string
-	}
-	imgs := make([]*imageV1, len(manifest.FSLayers))
-	for i := range manifest.FSLayers {
-		img := &imageV1{}
-
-		if err := json.Unmarshal([]byte(manifest.History[i].V1Compatibility), img); err != nil {
-			return err
-		}
-
-		imgs[i] = img
-		if err := validateV1ID(img.ID); err != nil {
-			return err
-		}
-	}
-	if imgs[len(imgs)-1].Parent != "" {
-		return errors.New("Invalid parent ID in the base layer of the image.")
-	}
-	// check general duplicates to error instead of a deadlock
-	idmap := make(map[string]struct{})
-	var lastID string
-	for _, img := range imgs {
-		// skip IDs that appear after each other, we handle those later
-		if _, exists := idmap[img.ID]; img.ID != lastID && exists {
-			return fmt.Errorf("ID %+v appears multiple times in manifest", img.ID)
-		}
-		lastID = img.ID
-		idmap[lastID] = struct{}{}
-	}
-	// backwards loop so that we keep the remaining indexes after removing items
-	for i := len(imgs) - 2; i >= 0; i-- {
-		if imgs[i].ID == imgs[i+1].ID { // repeated ID. remove and continue
-			manifest.FSLayers = append(manifest.FSLayers[:i], manifest.FSLayers[i+1:]...)
-			manifest.History = append(manifest.History[:i], manifest.History[i+1:]...)
-		} else if imgs[i].Parent != imgs[i+1].ID {
-			return fmt.Errorf("Invalid parent ID. Expected %v, got %v.", imgs[i+1].ID, imgs[i].Parent)
-		}
-	}
-	return nil
-}
-
-func validateV1ID(id string) error {
-	if ok := validHex.MatchString(id); !ok {
-		return fmt.Errorf("image ID %q is invalid", id)
-	}
-	return nil
 }

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -1,4 +1,4 @@
-package main
+package docker
 
 import (
 	"bytes"

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -2,14 +2,22 @@ package docker
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
+	"regexp"
+	"strings"
+	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/projectatomic/skopeo/reference"
 	"github.com/projectatomic/skopeo/types"
+)
+
+var (
+	validHex = regexp.MustCompile(`^([a-f0-9]{64})$`)
 )
 
 type errFetchManifest struct {
@@ -65,9 +73,35 @@ func (s *dockerImageSource) GetManifest() (manifest types.ImageManifest, unverif
 	if res.StatusCode != http.StatusOK {
 		return nil, "", errFetchManifest{res.StatusCode, manblob}
 	}
+	// TODO(remove, already set in manifest, below): Miloslav?
 	unverifiedCanonicalDigest = res.Header.Get("Docker-Content-Digest")
-	manifest, err = makeImageManifest(s.ref.FullName(), manblob, unverifiedCanonicalDigest, nil)
+	tags, err := s.getTags()
+	if err != nil {
+		return nil, "", err
+	}
+	manifest, err = makeImageManifest(s.ref.FullName(), manblob, res.Header.Get("Docker-Content-Digest"), tags)
 	return
+}
+
+func (s *dockerImageSource) getTags() ([]string, error) {
+	url := fmt.Sprintf(tagsURL, s.ref.RemoteName())
+	res, err := s.c.makeRequest("GET", url, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		// print url also
+		return nil, fmt.Errorf("Invalid status code returned when fetching tags list %d", res.StatusCode)
+	}
+	type tagsRes struct {
+		Tags []string
+	}
+	tags := &tagsRes{}
+	if err := json.NewDecoder(res.Body).Decode(tags); err != nil {
+		return nil, err
+	}
+	return tags.Tags, nil
 }
 
 func (s *dockerImageSource) GetLayer(digest string) (io.ReadCloser, error) {
@@ -86,6 +120,54 @@ func (s *dockerImageSource) GetLayer(digest string) (io.ReadCloser, error) {
 
 func (s *dockerImageSource) GetSignatures() ([][]byte, error) {
 	return [][]byte{}, nil
+}
+
+type v1Image struct {
+	// Config is the configuration of the container received from the client
+	Config *config `json:"config,omitempty"`
+	// DockerVersion specifies version on which image is built
+	DockerVersion string `json:"docker_version,omitempty"`
+	// Created timestamp when image was created
+	Created time.Time `json:"created"`
+	// Architecture is the hardware that the image is build and runs on
+	Architecture string `json:"architecture,omitempty"`
+	// OS is the operating system used to build and run the image
+	OS string `json:"os,omitempty"`
+}
+
+// will support v1 one day...
+type manifest interface {
+	String() string
+	GetLayers() []string
+}
+
+type manifestSchema1 struct {
+	Name     string
+	Tag      string
+	FSLayers []struct {
+		BlobSum string `json:"blobSum"`
+	} `json:"fsLayers"`
+	History []struct {
+		V1Compatibility string `json:"v1Compatibility"`
+	} `json:"history"`
+	// TODO(runcom) verify the downloaded manifest
+	//Signature []byte `json:"signature"`
+}
+
+func (m *manifestSchema1) GetLayers() []string {
+	layers := make([]string, len(m.FSLayers))
+	for i, layer := range m.FSLayers {
+		layers[i] = layer.BlobSum
+	}
+	return layers
+}
+
+func (m *manifestSchema1) String() string {
+	return fmt.Sprintf("%s-%s", sanitize(m.Name), sanitize(m.Tag))
+}
+
+func sanitize(s string) string {
+	return strings.Replace(s, "/", "-", -1)
 }
 
 func makeImageManifest(name string, manblob []byte, dgst string, tagList []string) (types.ImageManifest, error) {
@@ -113,4 +195,55 @@ func makeImageManifest(name string, manblob []byte, dgst string, tagList []strin
 		FSLayers:      m.GetLayers(),
 		RawManifest:   manblob,
 	}, nil
+}
+
+func fixManifestLayers(manifest *manifestSchema1) error {
+	type imageV1 struct {
+		ID     string
+		Parent string
+	}
+	imgs := make([]*imageV1, len(manifest.FSLayers))
+	for i := range manifest.FSLayers {
+		img := &imageV1{}
+
+		if err := json.Unmarshal([]byte(manifest.History[i].V1Compatibility), img); err != nil {
+			return err
+		}
+
+		imgs[i] = img
+		if err := validateV1ID(img.ID); err != nil {
+			return err
+		}
+	}
+	if imgs[len(imgs)-1].Parent != "" {
+		return errors.New("Invalid parent ID in the base layer of the image.")
+	}
+	// check general duplicates to error instead of a deadlock
+	idmap := make(map[string]struct{})
+	var lastID string
+	for _, img := range imgs {
+		// skip IDs that appear after each other, we handle those later
+		if _, exists := idmap[img.ID]; img.ID != lastID && exists {
+			return fmt.Errorf("ID %+v appears multiple times in manifest", img.ID)
+		}
+		lastID = img.ID
+		idmap[lastID] = struct{}{}
+	}
+	// backwards loop so that we keep the remaining indexes after removing items
+	for i := len(imgs) - 2; i >= 0; i-- {
+		if imgs[i].ID == imgs[i+1].ID { // repeated ID. remove and continue
+			manifest.FSLayers = append(manifest.FSLayers[:i], manifest.FSLayers[i+1:]...)
+			manifest.History = append(manifest.History[:i], manifest.History[i+1:]...)
+		} else if imgs[i].Parent != imgs[i+1].ID {
+			return fmt.Errorf("Invalid parent ID. Expected %v, got %v.", imgs[i+1].ID, imgs[i].Parent)
+		}
+	}
+	return nil
+}
+
+func validateV1ID(id string) error {
+	if ok := validHex.MatchString(id); !ok {
+		return fmt.Errorf("image ID %q is invalid", id)
+	}
+	return nil
 }

--- a/docker/docker_utils.go
+++ b/docker/docker_utils.go
@@ -1,4 +1,4 @@
-package main
+package docker
 
 import "github.com/projectatomic/skopeo/reference"
 

--- a/openshift/openshift-copies.go
+++ b/openshift/openshift-copies.go
@@ -1,4 +1,4 @@
-package main
+package openshift
 
 import (
 	"crypto/tls"

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -1,4 +1,4 @@
-package main
+package openshift
 
 import (
 	"bytes"
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/projectatomic/skopeo/docker"
 	"github.com/projectatomic/skopeo/dockerutils"
 	"github.com/projectatomic/skopeo/types"
 	"github.com/projectatomic/skopeo/version"
@@ -178,7 +179,7 @@ func NewOpenshiftImageSource(imageName, certPath string, tlsVerify bool) (types.
 	}, nil
 }
 
-func (s *openshiftImageSource) GetManifest() (manifest []byte, unverifiedCanonicalDigest string, err error) {
+func (s *openshiftImageSource) GetManifest() (manifest types.ImageManifest, unverifiedCanonicalDigest string, err error) {
 	if err := s.ensureImageIsResolved(); err != nil {
 		return nil, "", err
 	}
@@ -232,7 +233,7 @@ func (s *openshiftImageSource) ensureImageIsResolved() error {
 		return err
 	}
 	logrus.Debugf("Resolved reference %#v", dockerRef)
-	d, err := NewDockerImageSource(dockerRef, s.certPath, s.tlsVerify)
+	d, err := docker.NewDockerImageSource(dockerRef, s.certPath, s.tlsVerify)
 	if err != nil {
 		return err
 	}
@@ -257,7 +258,7 @@ func NewOpenshiftImageDestination(imageName, certPath string, tlsVerify bool) (t
 	// i.e. a single signed image cannot be available under multiple tags.  But with types.ImageDestination, we don't know
 	// the manifest digest at this point.
 	dockerRef := fmt.Sprintf("%s/%s/%s:%s", client.dockerRegistryHostPart(), client.namespace, client.stream, client.tag)
-	docker, err := NewDockerImageDestination(dockerRef, certPath, tlsVerify)
+	docker, err := docker.NewDockerImageDestination(dockerRef, certPath, tlsVerify)
 	if err != nil {
 		return nil, err
 	}

--- a/types/types.go
+++ b/types/types.go
@@ -30,7 +30,7 @@ type Repository interface {
 
 // ImageSource is a service, possibly remote (= slow), to download components of a single image.
 type ImageSource interface {
-	GetManifest() (manifest []byte, unverifiedCanonicalDigest string, err error)
+	GetManifest() (manifest ImageManifest, unverifiedCanonicalDigest string, err error)
 	GetLayer(digest string) (io.ReadCloser, error)
 	GetSignatures() ([][]byte, error)
 }
@@ -56,12 +56,15 @@ type Image interface {
 // ImageManifest is the interesting subset of metadata about an Image.
 // TODO(runcom)
 type ImageManifest interface {
+	Raw() []byte
+	Layers() []string
 	String() string
 }
 
 // DockerImageManifest is a set of metadata describing Docker images and their manifest.json files.
 // Note that this is not exactly manifest.json, e.g. some fields have been added.
 type DockerImageManifest struct {
+	RawManifest   []byte `json:"-"`
 	Name          string
 	Tag           string
 	Digest        string
@@ -71,7 +74,17 @@ type DockerImageManifest struct {
 	Labels        map[string]string
 	Architecture  string
 	Os            string
-	Layers        []string
+	FSLayers      []string
+}
+
+// Raw returns the raw manifest as received from the registry
+func (m *DockerImageManifest) Raw() []byte {
+	return m.RawManifest
+}
+
+// Layers returns a list of the FS layers in the manifest
+func (m *DockerImageManifest) Layers() []string {
+	return m.FSLayers
 }
 
 func (m *DockerImageManifest) String() string {

--- a/types/types.go
+++ b/types/types.go
@@ -74,7 +74,7 @@ type DockerImageManifest struct {
 	Labels        map[string]string
 	Architecture  string
 	Os            string
-	FSLayers      []string
+	FSLayers      []string `json:"Layers"`
 }
 
 // Raw returns the raw manifest as received from the registry


### PR DESCRIPTION
@mtrmac PTAL (I've also added some TODO)

This is just another small steps in defining a good API for sub pkgs (which could be later used by other pkgs, i.e. k8s)
Eventually I'd love to remove `docker/docker_image.go` and integrate relevand code either in img src or img dest. (@mtrmac please confirm this is your view also :smile: )
The major change (other then moving files around) is that I've strongly types `GetManifest()` to return an interface (with some methods just added) so it will work across implementation.

Again, this is still a WIP but I would like to have this merged and tested as we going forward with this (and also avoid having to review 10k LOC PRs :) :) :))

This code compiles right but I'd love if you could test it out (specifically for openshift related stuff and signing)

Signed-off-by: Antonio Murdaca <runcom@redhat.com>