### PR TITLE
signature cleanups

### DIFF
--- a/signature/json.go
+++ b/signature/json.go
@@ -1,0 +1,51 @@
+package signature
+
+import "fmt"
+
+// jsonFormatError is returned when JSON does not match expected format.
+type jsonFormatError string
+
+func (err jsonFormatError) Error() string {
+	return string(err)
+}
+
+// validateExactMapKeys returns an error if the keys of m are not exactly expectedKeys, which must be pairwise distinct
+func validateExactMapKeys(m map[string]interface{}, expectedKeys ...string) error {
+	if len(m) != len(expectedKeys) {
+		return jsonFormatError("Unexpected keys in a JSON object")
+	}
+
+	for _, k := range expectedKeys {
+		if _, ok := m[k]; !ok {
+			return jsonFormatError(fmt.Sprintf("Key %s missing in a JSON object", k))
+		}
+	}
+	// Assuming expectedKeys are pairwise distinct, we know m contains len(expectedKeys) different values in expectedKeys.
+	return nil
+}
+
+// mapField returns a member fieldName of m, if it is a JSON map, or an error.
+func mapField(m map[string]interface{}, fieldName string) (map[string]interface{}, error) {
+	untyped, ok := m[fieldName]
+	if !ok {
+		return nil, jsonFormatError(fmt.Sprintf("Field %s missing", fieldName))
+	}
+	v, ok := untyped.(map[string]interface{})
+	if !ok {
+		return nil, jsonFormatError(fmt.Sprintf("Field %s is not a JSON object", fieldName))
+	}
+	return v, nil
+}
+
+// stringField returns a member fieldName of m, if it is a string, or an error.
+func stringField(m map[string]interface{}, fieldName string) (string, error) {
+	untyped, ok := m[fieldName]
+	if !ok {
+		return "", jsonFormatError(fmt.Sprintf("Field %s missing", fieldName))
+	}
+	v, ok := untyped.(string)
+	if !ok {
+		return "", jsonFormatError(fmt.Sprintf("Field %s is not a JSON object", fieldName))
+	}
+	return v, nil
+}

--- a/signature/json_test.go
+++ b/signature/json_test.go
@@ -9,6 +9,18 @@ import (
 
 type mSI map[string]interface{} // To minimize typing the long name
 
+// A short-hand way to get a JSON object field value or panic. No error handling done, we know
+// what we are working with, a panic in a test is good enough, and fitting test cases on a single line
+// is a priority.
+func x(m mSI, fields ...string) mSI {
+	for _, field := range fields {
+		// Not .(mSI) because type assertion of an unnamed type to a named type always fails (the types
+		// are not "identical"), but the assignment is fine because they are "assignable".
+		m = m[field].(map[string]interface{})
+	}
+	return m
+}
+
 func TestValidateExactMapKeys(t *testing.T) {
 	// Empty map and keys
 	err := validateExactMapKeys(mSI{})

--- a/signature/json_test.go
+++ b/signature/json_test.go
@@ -1,0 +1,64 @@
+package signature
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mSI map[string]interface{} // To minimize typing the long name
+
+func TestValidateExactMapKeys(t *testing.T) {
+	// Empty map and keys
+	err := validateExactMapKeys(mSI{})
+	assert.NoError(t, err)
+
+	// Success
+	err = validateExactMapKeys(mSI{"a": nil, "b": 1}, "b", "a")
+	assert.NoError(t, err)
+
+	// Extra map keys
+	err = validateExactMapKeys(mSI{"a": nil, "b": 1}, "a")
+	assert.Error(t, err)
+
+	// Extra expected keys
+	err = validateExactMapKeys(mSI{"a": 1}, "b", "a")
+	assert.Error(t, err)
+
+	// Unexpected key values
+	err = validateExactMapKeys(mSI{"a": 1}, "b")
+	assert.Error(t, err)
+}
+
+func TestMapField(t *testing.T) {
+	// Field not found
+	_, err := mapField(mSI{"a": mSI{}}, "b")
+	assert.Error(t, err)
+
+	// Field has a wrong type
+	_, err = mapField(mSI{"a": 1}, "a")
+	assert.Error(t, err)
+
+	// Success
+	// FIXME? We can't use mSI as the type of child, that type apparently can't be converted to the raw map type.
+	child := map[string]interface{}{"b": mSI{}}
+	m, err := mapField(mSI{"a": child, "b": nil}, "a")
+	require.NoError(t, err)
+	assert.Equal(t, child, m)
+}
+
+func TestStringField(t *testing.T) {
+	// Field not found
+	_, err := stringField(mSI{"a": "x"}, "b")
+	assert.Error(t, err)
+
+	// Field has a wrong type
+	_, err = stringField(mSI{"a": 1}, "a")
+	assert.Error(t, err)
+
+	// Success
+	s, err := stringField(mSI{"a": "x", "b": nil}, "a")
+	require.NoError(t, err)
+	assert.Equal(t, "x", s)
+}

--- a/signature/mechanism.go
+++ b/signature/mechanism.go
@@ -1,3 +1,5 @@
+// Note: Consider the API unstable until the code supports at least three different image formats or transports.
+
 package signature
 
 import (

--- a/signature/signature.go
+++ b/signature/signature.go
@@ -36,6 +36,9 @@ type privateSignature struct {
 	Signature
 }
 
+// Compile-time check that privateSignature implements json.Marshaler
+var _ json.Marshaler = (*privateSignature)(nil)
+
 // MarshalJSON implements the json.Marshaler interface.
 func (s privateSignature) MarshalJSON() ([]byte, error) {
 	return s.marshalJSONWithVariables(time.Now().UTC().Unix(), signatureCreatorID)
@@ -102,6 +105,9 @@ func stringField(m map[string]interface{}, fieldName string) (string, error) {
 	}
 	return v, nil
 }
+
+// Compile-time check that privateSignature implements json.Unmarshaler
+var _ json.Unmarshaler = (*privateSignature)(nil)
 
 // UnmarshalJSON implements the json.Unmarshaler interface
 func (s *privateSignature) UnmarshalJSON(data []byte) error {

--- a/signature/signature_test.go
+++ b/signature/signature_test.go
@@ -39,18 +39,6 @@ func TestMarshalJSON(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-// A short-hand way to get a JSON object field value or panic. No error handling done, we know
-// what we are working with, a panic in a test is good enough, and fitting test cases on a single line
-// is a priority.
-func x(m mSI, fields ...string) mSI {
-	for _, field := range fields {
-		// Not .(mSI) because type assertion of an unnamed type to a named type always fails (the types
-		// are not "identical"), but the assignment is fine because they are "assignable".
-		m = m[field].(map[string]interface{})
-	}
-	return m
-}
-
 // Return the result of modifying validJSON with fn and unmarshaling it into *sig
 func tryUnmarshalModifiedSignature(t *testing.T, sig *privateSignature, validJSON []byte, modifyFn func(mSI)) error {
 	var tmp mSI

--- a/signature/signature_test.go
+++ b/signature/signature_test.go
@@ -52,7 +52,7 @@ func x(m mSI, fields ...string) mSI {
 }
 
 // Return the result of modifying validJSON with fn and unmarshaling it into *sig
-func tryUnmarshalModified(t *testing.T, sig *privateSignature, validJSON []byte, modifyFn func(mSI)) error {
+func tryUnmarshalModifiedSignature(t *testing.T, sig *privateSignature, validJSON []byte, modifyFn func(mSI)) error {
 	var tmp mSI
 	err := json.Unmarshal(validJSON, &tmp)
 	require.NoError(t, err)
@@ -128,7 +128,7 @@ func TestUnmarshalJSON(t *testing.T) {
 		func(v mSI) { x(v, "critical", "identity")["docker-reference"] = 1 },
 	}
 	for _, fn := range breakFns {
-		err = tryUnmarshalModified(t, &s, validJSON, fn)
+		err = tryUnmarshalModifiedSignature(t, &s, validJSON, fn)
 		assert.Error(t, err)
 	}
 
@@ -141,7 +141,7 @@ func TestUnmarshalJSON(t *testing.T) {
 	}
 	for _, fn := range allowedModificationFns {
 		s = privateSignature{}
-		err = tryUnmarshalModified(t, &s, validJSON, fn)
+		err = tryUnmarshalModifiedSignature(t, &s, validJSON, fn)
 		require.NoError(t, err)
 		assert.Equal(t, validSig, s)
 	}

--- a/signature/signature_test.go
+++ b/signature/signature_test.go
@@ -147,10 +147,6 @@ func TestUnmarshalJSON(t *testing.T) {
 	}
 }
 
-type savedEnvironment struct {
-	vars []string
-}
-
 func TestSign(t *testing.T) {
 	mech, err := newGPGSigningMechanismInDirectory(testGPGHomeDirectory)
 	require.NoError(t, err)

--- a/signature/signature_test.go
+++ b/signature/signature_test.go
@@ -62,6 +62,7 @@ func tryUnmarshalModifiedSignature(t *testing.T, sig *privateSignature, validJSO
 	testJSON, err := json.Marshal(tmp)
 	require.NoError(t, err)
 
+	*sig = privateSignature{}
 	return json.Unmarshal(testJSON, sig)
 }
 
@@ -140,7 +141,6 @@ func TestUnmarshalJSON(t *testing.T) {
 		func(v mSI) { delete(x(v, "optional"), "creator") },
 	}
 	for _, fn := range allowedModificationFns {
-		s = privateSignature{}
 		err = tryUnmarshalModifiedSignature(t, &s, validJSON, fn)
 		require.NoError(t, err)
 		assert.Equal(t, validSig, s)

--- a/signature/signature_test.go
+++ b/signature/signature_test.go
@@ -39,62 +39,6 @@ func TestMarshalJSON(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-type mSI map[string]interface{} // To minimize typing the long name
-
-func TestValidateExactMapKeys(t *testing.T) {
-	// Empty map and keys
-	err := validateExactMapKeys(mSI{})
-	assert.NoError(t, err)
-
-	// Success
-	err = validateExactMapKeys(mSI{"a": nil, "b": 1}, "b", "a")
-	assert.NoError(t, err)
-
-	// Extra map keys
-	err = validateExactMapKeys(mSI{"a": nil, "b": 1}, "a")
-	assert.Error(t, err)
-
-	// Extra expected keys
-	err = validateExactMapKeys(mSI{"a": 1}, "b", "a")
-	assert.Error(t, err)
-
-	// Unexpected key values
-	err = validateExactMapKeys(mSI{"a": 1}, "b")
-	assert.Error(t, err)
-}
-
-func TestMapField(t *testing.T) {
-	// Field not found
-	_, err := mapField(mSI{"a": mSI{}}, "b")
-	assert.Error(t, err)
-
-	// Field has a wrong type
-	_, err = mapField(mSI{"a": 1}, "a")
-	assert.Error(t, err)
-
-	// Success
-	// FIXME? We can't use mSI as the type of child, that type apparently can't be converted to the raw map type.
-	child := map[string]interface{}{"b": mSI{}}
-	m, err := mapField(mSI{"a": child, "b": nil}, "a")
-	require.NoError(t, err)
-	assert.Equal(t, child, m)
-}
-
-func TestStringField(t *testing.T) {
-	// Field not found
-	_, err := stringField(mSI{"a": "x"}, "b")
-	assert.Error(t, err)
-
-	// Field has a wrong type
-	_, err = stringField(mSI{"a": 1}, "a")
-	assert.Error(t, err)
-
-	// Success
-	s, err := stringField(mSI{"a": "x", "b": nil}, "a")
-	require.NoError(t, err)
-	assert.Equal(t, "x", s)
-}
-
 // A short-hand way to get a JSON object field value or panic. No error handling done, we know
 // what we are working with, a panic in a test is good enough, and fitting test cases on a single line
 // is a priority.


### PR DESCRIPTION
Splitting from the main policy work for easier review. This should not change behavior at all, only moving some utilities into a separate file, adding comments, some trivial cleanups.