### PR TITLE
Move directory, docker and openshift from cmd/skopeo to their own subpackages

### DIFF
--- a/cmd/skopeo/copy.go
+++ b/cmd/skopeo/copy.go
@@ -24,6 +24,20 @@ func manifestLayers(manifest []byte) ([]string, error) {
 	return layers, nil
 }
 
+// FIXME: this is a copy from docker_image.go and does not belong here.
+type manifestSchema1 struct {
+	Name     string
+	Tag      string
+	FSLayers []struct {
+		BlobSum string `json:"blobSum"`
+	} `json:"fsLayers"`
+	History []struct {
+		V1Compatibility string `json:"v1Compatibility"`
+	} `json:"history"`
+	// TODO(runcom) verify the downloaded manifest
+	//Signature []byte `json:"signature"`
+}
+
 func copyHandler(context *cli.Context) {
 	if len(context.Args()) != 2 {
 		logrus.Fatal("Usage: copy source destination")

--- a/cmd/skopeo/utils.go
+++ b/cmd/skopeo/utils.go
@@ -5,6 +5,9 @@ import (
 	"strings"
 
 	"github.com/codegangsta/cli"
+	"github.com/projectatomic/skopeo/directory"
+	"github.com/projectatomic/skopeo/docker"
+	"github.com/projectatomic/skopeo/openshift"
 	"github.com/projectatomic/skopeo/types"
 )
 
@@ -17,7 +20,7 @@ func parseImage(c *cli.Context) (types.Image, error) {
 	)
 	switch {
 	case strings.HasPrefix(imgName, types.DockerPrefix):
-		return parseDockerImage(strings.TrimPrefix(imgName, types.DockerPrefix), certPath, tlsVerify)
+		return docker.NewDockerImage(strings.TrimPrefix(imgName, types.DockerPrefix), certPath, tlsVerify)
 		//case strings.HasPrefix(img, appcPrefix):
 		//
 	}
@@ -32,11 +35,11 @@ func parseImageSource(c *cli.Context, name string) (types.ImageSource, error) {
 	)
 	switch {
 	case strings.HasPrefix(name, types.DockerPrefix):
-		return NewDockerImageSource(strings.TrimPrefix(name, types.DockerPrefix), certPath, tlsVerify)
+		return docker.NewDockerImageSource(strings.TrimPrefix(name, types.DockerPrefix), certPath, tlsVerify)
 	case strings.HasPrefix(name, types.AtomicPrefix):
-		return NewOpenshiftImageSource(strings.TrimPrefix(name, types.AtomicPrefix), certPath, tlsVerify)
+		return openshift.NewOpenshiftImageSource(strings.TrimPrefix(name, types.AtomicPrefix), certPath, tlsVerify)
 	case strings.HasPrefix(name, types.DirectoryPrefix):
-		return NewDirImageSource(strings.TrimPrefix(name, types.DirectoryPrefix)), nil
+		return directory.NewDirImageSource(strings.TrimPrefix(name, types.DirectoryPrefix)), nil
 	}
 	return nil, fmt.Errorf("Unrecognized image reference %s", name)
 }
@@ -49,11 +52,11 @@ func parseImageDestination(c *cli.Context, name string) (types.ImageDestination,
 	)
 	switch {
 	case strings.HasPrefix(name, types.DockerPrefix):
-		return NewDockerImageDestination(strings.TrimPrefix(name, types.DockerPrefix), certPath, tlsVerify)
+		return docker.NewDockerImageDestination(strings.TrimPrefix(name, types.DockerPrefix), certPath, tlsVerify)
 	case strings.HasPrefix(name, types.AtomicPrefix):
-		return NewOpenshiftImageDestination(strings.TrimPrefix(name, types.AtomicPrefix), certPath, tlsVerify)
+		return openshift.NewOpenshiftImageDestination(strings.TrimPrefix(name, types.AtomicPrefix), certPath, tlsVerify)
 	case strings.HasPrefix(name, types.DirectoryPrefix):
-		return NewDirImageDestination(strings.TrimPrefix(name, types.DirectoryPrefix)), nil
+		return directory.NewDirImageDestination(strings.TrimPrefix(name, types.DirectoryPrefix)), nil
 	}
 	return nil, fmt.Errorf("Unrecognized image reference %s", name)
 }

--- a/directory/directory.go
+++ b/directory/directory.go
@@ -1,4 +1,4 @@
-package main
+package directory
 
 import (
 	"fmt"

--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -1,4 +1,4 @@
-package main
+package docker
 
 import (
 	"crypto/tls"

--- a/docker/docker_image.go
+++ b/docker/docker_image.go
@@ -1,4 +1,4 @@
-package main
+package docker
 
 import (
 	"encoding/json"
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/projectatomic/skopeo/directory"
 	"github.com/projectatomic/skopeo/types"
 )
 
@@ -23,7 +24,9 @@ type dockerImage struct {
 	rawManifest []byte
 }
 
-func parseDockerImage(img, certPath string, tlsVerify bool) (types.Image, error) {
+// NewDockerImage returns a new Image interface type after setting up
+// a client to the registry hosting the given image.
+func NewDockerImage(img, certPath string, tlsVerify bool) (types.Image, error) {
 	s, err := newDockerImageSource(img, certPath, tlsVerify)
 	if err != nil {
 		return nil, err
@@ -201,7 +204,7 @@ func (i *dockerImage) Layers(layers ...string) error {
 	if err != nil {
 		return err
 	}
-	dest := NewDirImageDestination(tmpDir)
+	dest := directory.NewDirImageDestination(tmpDir)
 	data, err := json.Marshal(m)
 	if err != nil {
 		return err

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -1,4 +1,4 @@
-package main
+package docker
 
 import (
 	"bytes"

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -1,4 +1,4 @@
-package main
+package docker
 
 import (
 	"fmt"

--- a/docker/docker_utils.go
+++ b/docker/docker_utils.go
@@ -1,4 +1,4 @@
-package main
+package docker
 
 import "github.com/projectatomic/skopeo/reference"
 

--- a/openshift/openshift-copies.go
+++ b/openshift/openshift-copies.go
@@ -1,4 +1,4 @@
-package main
+package openshift
 
 import (
 	"crypto/tls"

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -1,4 +1,4 @@
-package main
+package openshift
 
 import (
 	"bytes"
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/projectatomic/skopeo/docker"
 	"github.com/projectatomic/skopeo/dockerutils"
 	"github.com/projectatomic/skopeo/types"
 	"github.com/projectatomic/skopeo/version"
@@ -232,7 +233,7 @@ func (s *openshiftImageSource) ensureImageIsResolved() error {
 		return err
 	}
 	logrus.Debugf("Resolved reference %#v", dockerRef)
-	d, err := NewDockerImageSource(dockerRef, s.certPath, s.tlsVerify)
+	d, err := docker.NewDockerImageSource(dockerRef, s.certPath, s.tlsVerify)
 	if err != nil {
 		return err
 	}
@@ -257,7 +258,7 @@ func NewOpenshiftImageDestination(imageName, certPath string, tlsVerify bool) (t
 	// i.e. a single signed image cannot be available under multiple tags.  But with types.ImageDestination, we don't know
 	// the manifest digest at this point.
 	dockerRef := fmt.Sprintf("%s/%s/%s:%s", client.dockerRegistryHostPart(), client.namespace, client.stream, client.tag)
-	docker, err := NewDockerImageDestination(dockerRef, certPath, tlsVerify)
+	docker, err := docker.NewDockerImageDestination(dockerRef, certPath, tlsVerify)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Does not change behavior.  This is a straightforward move and update of package references, except for:

- Adding a duplicate definition of `manifestSchema1` to `cmd/skopeo/copy.go`.  This will need to be cleaned up later, for now preferring to make no design changes in this commit.
- Renaming `parseDockerImage` to `NewDockerImage`, to both make it public and consistent with common golang conventions.