### PR TITLE
API for signatures

### DIFF
--- a/cmd/skopeo/inspect.go
+++ b/cmd/skopeo/inspect.go
@@ -23,8 +23,7 @@ var inspectCmd = cli.Command{
 			logrus.Fatal(err)
 		}
 		if c.Bool("raw") {
-			// TODO(runcom): hardcoded schema 2 version 1
-			b, err := img.RawManifest("2-1")
+			b, err := img.GetManifest()
 			if err != nil {
 				logrus.Fatal(err)
 			}

--- a/directory/directory.go
+++ b/directory/directory.go
@@ -77,6 +77,13 @@ func NewDirImageSource(dir string) types.ImageSource {
 	return &dirImageSource{dir}
 }
 
+// GetIntendedDockerReference returns the full, unambiguous, Docker reference for this image, _as specified by the user_
+// (not as the image itself, or its underlying storage, claims).  This can be used e.g. to determine which public keys are trusted for this image.
+// May be "" if unknown.
+func (s *dirImageSource) GetIntendedDockerReference() string {
+	return ""
+}
+
 func (s *dirImageSource) GetManifest() ([]byte, string, error) {
 	manifest, err := ioutil.ReadFile(manifestPath(s.dir))
 	if err != nil {

--- a/docker/docker_image.go
+++ b/docker/docker_image.go
@@ -19,9 +19,10 @@ var (
 )
 
 type dockerImage struct {
-	src         *dockerImageSource
-	digest      string
-	rawManifest []byte
+	src              *dockerImageSource
+	digest           string
+	rawManifest      []byte
+	cachedSignatures [][]byte // Private cache for GetSignatures; nil if not yet known.
 }
 
 // NewDockerImage returns a new Image interface type after setting up
@@ -34,12 +35,24 @@ func NewDockerImage(img, certPath string, tlsVerify bool) (types.Image, error) {
 	return &dockerImage{src: s}, nil
 }
 
-func (i *dockerImage) RawManifest(version string) ([]byte, error) {
-	// TODO(runcom): unused version param for now, default to docker v2-1
+// GetManifest is like ImageSource.GetManifest, but the result is cached; it is OK to call this however often you need.
+func (i *dockerImage) GetManifest() ([]byte, error) {
 	if err := i.retrieveRawManifest(); err != nil {
 		return nil, err
 	}
 	return i.rawManifest, nil
+}
+
+// GetSignatures is like ImageSource.GetSignatures, but the result is cached; it is OK to call this however often you need.
+func (i *dockerImage) GetSignatures() ([][]byte, error) {
+	if i.cachedSignatures == nil {
+		sigs, err := i.src.GetSignatures()
+		if err != nil {
+			return nil, err
+		}
+		i.cachedSignatures = sigs
+	}
+	return i.cachedSignatures, nil
 }
 
 func (i *dockerImage) Manifest() (types.ImageManifest, error) {

--- a/docker/docker_image.go
+++ b/docker/docker_image.go
@@ -35,6 +35,13 @@ func NewDockerImage(img, certPath string, tlsVerify bool) (types.Image, error) {
 	return &dockerImage{src: s}, nil
 }
 
+// GetIntendedDockerReference returns the full, unambiguous, Docker reference for this image, _as specified by the user_
+// (not as the image itself, or its underlying storage, claims).  This can be used e.g. to determine which public keys are trusted for this image.
+// May be "" if unknown.
+func (i *dockerImage) GetIntendedDockerReference() string {
+	return i.src.GetIntendedDockerReference()
+}
+
 // GetManifest is like ImageSource.GetManifest, but the result is cached; it is OK to call this however often you need.
 func (i *dockerImage) GetManifest() ([]byte, error) {
 	if err := i.retrieveRawManifest(); err != nil {

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -48,6 +48,13 @@ func NewDockerImageSource(img, certPath string, tlsVerify bool) (types.ImageSour
 	return newDockerImageSource(img, certPath, tlsVerify)
 }
 
+// GetIntendedDockerReference returns the full, unambiguous, Docker reference for this image, _as specified by the user_
+// (not as the image itself, or its underlying storage, claims).  This can be used e.g. to determine which public keys are trusted for this image.
+// May be "" if unknown.
+func (s *dockerImageSource) GetIntendedDockerReference() string {
+	return fmt.Sprintf("%s:%s", s.ref.Name(), s.tag)
+}
+
 func (s *dockerImageSource) GetManifest() (manifest []byte, unverifiedCanonicalDigest string, err error) {
 	url := fmt.Sprintf(manifestURL, s.ref.RemoteName(), s.tag)
 	// TODO(runcom) set manifest version header! schema1 for now - then schema2 etc etc and v1

--- a/types/types.go
+++ b/types/types.go
@@ -47,9 +47,12 @@ type ImageDestination interface {
 // Image is a Docker image in a repository.
 type Image interface {
 	// ref to repository?
+	// GetManifest is like ImageSource.GetManifest, but the result is cached; it is OK to call this however often you need.
+	GetManifest() ([]byte, error)
+	// GetSignatures is like ImageSource.GetSignatures, but the result is cached; it is OK to call this however often you need.
+	GetSignatures() ([][]byte, error)
 	Layers(layers ...string) error // configure download directory? Call it DownloadLayers?
 	Manifest() (ImageManifest, error)
-	RawManifest(version string) ([]byte, error)
 	DockerTar() ([]byte, error) // ??? also, configure output directory
 }
 

--- a/types/types.go
+++ b/types/types.go
@@ -30,6 +30,10 @@ type Repository interface {
 
 // ImageSource is a service, possibly remote (= slow), to download components of a single image.
 type ImageSource interface {
+	// GetIntendedDockerReference returns the full, unambiguous, Docker reference for this image, _as specified by the user_
+	// (not as the image itself, or its underlying storage, claims).  This can be used e.g. to determine which public keys are trusted for this image.
+	// May be "" if unknown.
+	GetIntendedDockerReference() string
 	GetManifest() (manifest []byte, unverifiedCanonicalDigest string, err error)
 	GetLayer(digest string) (io.ReadCloser, error)
 	GetSignatures() ([][]byte, error)
@@ -47,6 +51,10 @@ type ImageDestination interface {
 // Image is a Docker image in a repository.
 type Image interface {
 	// ref to repository?
+	// GetIntendedDockerReference returns the full, unambiguous, Docker reference for this image, _as specified by the user_
+	// (not as the image itself, or its underlying storage, claims).  This can be used e.g. to determine which public keys are trusted for this image.
+	// May be "" if unknown.
+	GetIntendedDockerReference() string
 	// GetManifest is like ImageSource.GetManifest, but the result is cached; it is OK to call this however often you need.
 	GetManifest() ([]byte, error)
 	// GetSignatures is like ImageSource.GetSignatures, but the result is cached; it is OK to call this however often you need.


### PR DESCRIPTION
This adds methods useful for validating signatures to `types.Image`, namely the ability to retrieve signatures, and the supposedly signed identity, and renames `RawManifest` for consistency.

The implementation remains Docker-specific (in particular, not usable for OpenShift), but having the type and API will allow the policy evaluation code to compile, which is on my critical path now.

See comments in the individual commits for details.