### PR TITLE
General image API cleanups

### DIFF
--- a/cmd/skopeo/copy.go
+++ b/cmd/skopeo/copy.go
@@ -54,7 +54,7 @@ func copyHandler(context *cli.Context) {
 	}
 	signBy := context.String("sign-by")
 
-	manifest, _, err := src.GetManifest()
+	manifest, err := src.GetManifest()
 	if err != nil {
 		logrus.Fatalf("Error reading manifest: %s", err.Error())
 	}

--- a/cmd/skopeo/inspect.go
+++ b/cmd/skopeo/inspect.go
@@ -3,10 +3,25 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
 )
+
+// inspectOutput is the output format of (skopeo inspect), primarily so that we can format it with a simple json.MarshalIndent.
+type inspectOutput struct {
+	Name          string
+	Tag           string
+	Digest        string
+	RepoTags      []string
+	Created       time.Time
+	DockerVersion string
+	Labels        map[string]string
+	Architecture  string
+	Os            string
+	Layers        []string
+}
 
 var inspectCmd = cli.Command{
 	Name:  "inspect",
@@ -34,7 +49,19 @@ var inspectCmd = cli.Command{
 		if err != nil {
 			logrus.Fatal(err)
 		}
-		out, err := json.MarshalIndent(imgInspect, "", "    ")
+		outputData := inspectOutput{
+			Name:          imgInspect.Name,
+			Tag:           imgInspect.Tag,
+			Digest:        imgInspect.Digest,
+			RepoTags:      imgInspect.RepoTags,
+			Created:       imgInspect.Created,
+			DockerVersion: imgInspect.DockerVersion,
+			Labels:        imgInspect.Labels,
+			Architecture:  imgInspect.Architecture,
+			Os:            imgInspect.Os,
+			Layers:        imgInspect.Layers,
+		}
+		out, err := json.MarshalIndent(outputData, "", "    ")
 		if err != nil {
 			logrus.Fatal(err)
 		}

--- a/cmd/skopeo/inspect.go
+++ b/cmd/skopeo/inspect.go
@@ -54,11 +54,15 @@ var inspectCmd = cli.Command{
 		if err != nil {
 			logrus.Fatalf("Error computing manifest digest: %s", err.Error())
 		}
+		repoTags, err := img.GetRepositoryTags()
+		if err != nil {
+			logrus.Fatalf("Error determining repository tags: %s", err.Error())
+		}
 		outputData := inspectOutput{
 			Name:          imgInspect.Name,
 			Tag:           imgInspect.Tag,
 			Digest:        manifestDigest,
-			RepoTags:      imgInspect.RepoTags,
+			RepoTags:      repoTags,
 			Created:       imgInspect.Created,
 			DockerVersion: imgInspect.DockerVersion,
 			Labels:        imgInspect.Labels,

--- a/directory/directory.go
+++ b/directory/directory.go
@@ -84,13 +84,8 @@ func (s *dirImageSource) IntendedDockerReference() string {
 	return ""
 }
 
-func (s *dirImageSource) GetManifest() ([]byte, string, error) {
-	manifest, err := ioutil.ReadFile(manifestPath(s.dir))
-	if err != nil {
-		return nil, "", err
-	}
-
-	return manifest, "", nil // FIXME? unverifiedCanonicalDigest value - really primarily used by dockerImage
+func (s *dirImageSource) GetManifest() ([]byte, error) {
+	return ioutil.ReadFile(manifestPath(s.dir))
 }
 
 func (s *dirImageSource) GetLayer(digest string) (io.ReadCloser, error) {

--- a/docker/docker_image.go
+++ b/docker/docker_image.go
@@ -62,7 +62,7 @@ func (i *dockerImage) Signatures() ([][]byte, error) {
 	return i.cachedSignatures, nil
 }
 
-func (i *dockerImage) Inspect() (types.ImageManifest, error) {
+func (i *dockerImage) Inspect() (*types.DockerImageManifest, error) {
 	// TODO(runcom): unused version param for now, default to docker v2-1
 	m, err := i.getSchema1Manifest()
 	if err != nil {
@@ -122,7 +122,7 @@ type v1Image struct {
 	OS string `json:"os,omitempty"`
 }
 
-func makeImageManifest(name string, m *manifestSchema1, dgst string, tagList []string) (types.ImageManifest, error) {
+func makeImageManifest(name string, m *manifestSchema1, dgst string, tagList []string) (*types.DockerImageManifest, error) {
 	v1 := &v1Image{}
 	if err := json.Unmarshal([]byte(m.History[0].V1Compatibility), v1); err != nil {
 		return nil, err

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -193,9 +193,9 @@ func (s *openshiftImageSource) IntendedDockerReference() string {
 	return s.client.canonicalDockerReference()
 }
 
-func (s *openshiftImageSource) GetManifest() (manifest []byte, unverifiedCanonicalDigest string, err error) {
+func (s *openshiftImageSource) GetManifest() ([]byte, error) {
 	if err := s.ensureImageIsResolved(); err != nil {
-		return nil, "", err
+		return nil, err
 	}
 	return s.docker.GetManifest()
 }

--- a/types/types.go
+++ b/types/types.go
@@ -62,14 +62,8 @@ type Image interface {
 	// Signatures is like ImageSource.GetSignatures, but the result is cached; it is OK to call this however often you need.
 	Signatures() ([][]byte, error)
 	Layers(layers ...string) error // configure download directory? Call it DownloadLayers?
-	Inspect() (ImageManifest, error)
+	Inspect() (*DockerImageManifest, error)
 	DockerTar() ([]byte, error) // ??? also, configure output directory
-}
-
-// ImageManifest is the interesting subset of metadata about an Image.
-// TODO(runcom)
-type ImageManifest interface {
-	String() string
 }
 
 // DockerImageManifest is a set of metadata describing Docker images and their manifest.json files.

--- a/types/types.go
+++ b/types/types.go
@@ -35,7 +35,7 @@ type ImageSource interface {
 	// May be "" if unknown.
 	IntendedDockerReference() string
 	// GetManifest returns the image's manifest.  It may use a remote (= slow) service.
-	GetManifest() (manifest []byte, unverifiedCanonicalDigest string, err error)
+	GetManifest() ([]byte, error)
 	GetLayer(digest string) (io.ReadCloser, error)
 	// GetSignatures returns the image's signatures.  It may use a remote (= slow) service.
 	GetSignatures() ([][]byte, error)
@@ -71,7 +71,6 @@ type Image interface {
 type DockerImageManifest struct {
 	Name          string
 	Tag           string
-	Digest        string
 	RepoTags      []string
 	Created       time.Time
 	DockerVersion string

--- a/types/types.go
+++ b/types/types.go
@@ -64,6 +64,8 @@ type Image interface {
 	Layers(layers ...string) error // configure download directory? Call it DownloadLayers?
 	Inspect() (*DockerImageManifest, error)
 	DockerTar() ([]byte, error) // ??? also, configure output directory
+	// GetRepositoryTags list all tags available in the repository. Note that this has no connection with the tag(s) used for this specific image, if any.
+	GetRepositoryTags() ([]string, error)
 }
 
 // DockerImageManifest is a set of metadata describing Docker images and their manifest.json files.
@@ -71,7 +73,6 @@ type Image interface {
 type DockerImageManifest struct {
 	Name          string
 	Tag           string
-	RepoTags      []string
 	Created       time.Time
 	DockerVersion string
 	Labels        map[string]string

--- a/types/types.go
+++ b/types/types.go
@@ -29,13 +29,17 @@ type Repository interface {
 }
 
 // ImageSource is a service, possibly remote (= slow), to download components of a single image.
+// This is primarily useful for copying images around; for examining their properties, Image (below)
+// is usually more useful.
 type ImageSource interface {
 	// IntendedDockerReference returns the full, unambiguous, Docker reference for this image, _as specified by the user_
 	// (not as the image itself, or its underlying storage, claims).  This can be used e.g. to determine which public keys are trusted for this image.
 	// May be "" if unknown.
 	IntendedDockerReference() string
 	// GetManifest returns the image's manifest.  It may use a remote (= slow) service.
+	// FIXME? This should also return a MIME type if known, to differentiate between schema versions.
 	GetManifest() ([]byte, error)
+	// Note: Calling GetLayer() may have ordering dependencies WRT other methods of this type. FIXME: How does this work with (docker save) on stdin?
 	GetLayer(digest string) (io.ReadCloser, error)
 	// GetSignatures returns the image's signatures.  It may use a remote (= slow) service.
 	GetSignatures() ([][]byte, error)
@@ -45,12 +49,14 @@ type ImageSource interface {
 type ImageDestination interface {
 	// CanonicalDockerReference returns the full, unambiguous, Docker reference for this image (even if the user referred to the image using some shorthand notation).
 	CanonicalDockerReference() (string, error)
+	// FIXME? This should also receive a MIME type if known, to differentiate between schema versions.
 	PutManifest([]byte) error
+	// Note: Calling PutLayer() and other methods may have ordering dependencies WRT other methods of this type. FIXME: Figure out and document.
 	PutLayer(digest string, stream io.Reader) error
 	PutSignatures(signatures [][]byte) error
 }
 
-// Image is a Docker image in a repository.
+// Image is the primary API for inspecting properties of images.
 type Image interface {
 	// ref to repository?
 	// IntendedDockerReference returns the full, unambiguous, Docker reference for this image, _as specified by the user_
@@ -58,6 +64,7 @@ type Image interface {
 	// May be "" if unknown.
 	IntendedDockerReference() string
 	// Manifest is like ImageSource.GetManifest, but the result is cached; it is OK to call this however often you need.
+	// FIXME? This should also return a MIME type if known, to differentiate between schema versions.
 	Manifest() ([]byte, error)
 	// Signatures is like ImageSource.GetSignatures, but the result is cached; it is OK to call this however often you need.
 	Signatures() ([][]byte, error)
@@ -65,6 +72,8 @@ type Image interface {
 	Inspect() (*ImageInspectInfo, error)
 	DockerTar() ([]byte, error) // ??? also, configure output directory
 	// GetRepositoryTags list all tags available in the repository. Note that this has no connection with the tag(s) used for this specific image, if any.
+	// Eventually we should move this away from the generic Image interface, and move it into a Docker-specific case within the (skopeo inspect) command,
+	// see https://github.com/projectatomic/skopeo/pull/58#discussion_r63411838 .
 	GetRepositoryTags() ([]string, error)
 }
 

--- a/types/types.go
+++ b/types/types.go
@@ -62,15 +62,14 @@ type Image interface {
 	// Signatures is like ImageSource.GetSignatures, but the result is cached; it is OK to call this however often you need.
 	Signatures() ([][]byte, error)
 	Layers(layers ...string) error // configure download directory? Call it DownloadLayers?
-	Inspect() (*DockerImageManifest, error)
+	Inspect() (*ImageInspectInfo, error)
 	DockerTar() ([]byte, error) // ??? also, configure output directory
 	// GetRepositoryTags list all tags available in the repository. Note that this has no connection with the tag(s) used for this specific image, if any.
 	GetRepositoryTags() ([]string, error)
 }
 
-// DockerImageManifest is a set of metadata describing Docker images and their manifest.json files.
-// Note that this is not exactly manifest.json, e.g. some fields have been added.
-type DockerImageManifest struct {
+// ImageInspectInfo is a set of metadata describing Docker images, primarily their manifest and configuration.
+type ImageInspectInfo struct {
 	Name          string
 	Tag           string
 	Created       time.Time
@@ -81,6 +80,6 @@ type DockerImageManifest struct {
 	Layers        []string
 }
 
-func (m *DockerImageManifest) String() string {
+func (m *ImageInspectInfo) String() string {
 	return fmt.Sprintf("%s:%s", m.Name, m.Tag)
 }


### PR DESCRIPTION
This is a follow-up to #57, I will rebase as needed.

This somewhat cleans up `types.Image` towards becoming the primary inspection endpoint for images:

 - We can now change the API without breaking `skopeo inspect` output format
 - `Image.Manifest` turns into `Image.Inspect`, which parses the manifest, config and layers only; its other former functions are split into new methods.
 - Added comments on how the API types are expected to be used.

This does not yet completely clean up the API (e.g. moving parts of `Layers` to `cmd/skopeo`).

Nor does this make `Image` independent of the underlying Docker implementation yet: (`InspectInfo.Name` returns the parsed Docker ref, and `GetRepositoryTags` needs a Docker client). Non-Docker replacements for this mostly depend on what values we define `skopeo inspect` to return for non-Docker sources.

See comments in the individual commits for details.