### PR TITLE
API for signatures - drop Get prefixes on quick getters

### DIFF
--- a/cmd/skopeo/inspect.go
+++ b/cmd/skopeo/inspect.go
@@ -30,7 +30,7 @@ var inspectCmd = cli.Command{
 			fmt.Println(string(b))
 			return
 		}
-		imgInspect, err := img.Manifest()
+		imgInspect, err := img.Inspect()
 		if err != nil {
 			logrus.Fatal(err)
 		}

--- a/cmd/skopeo/inspect.go
+++ b/cmd/skopeo/inspect.go
@@ -23,7 +23,7 @@ var inspectCmd = cli.Command{
 			logrus.Fatal(err)
 		}
 		if c.Bool("raw") {
-			b, err := img.GetManifest()
+			b, err := img.Manifest()
 			if err != nil {
 				logrus.Fatal(err)
 			}

--- a/directory/directory.go
+++ b/directory/directory.go
@@ -77,10 +77,10 @@ func NewDirImageSource(dir string) types.ImageSource {
 	return &dirImageSource{dir}
 }
 
-// GetIntendedDockerReference returns the full, unambiguous, Docker reference for this image, _as specified by the user_
+// IntendedDockerReference returns the full, unambiguous, Docker reference for this image, _as specified by the user_
 // (not as the image itself, or its underlying storage, claims).  This can be used e.g. to determine which public keys are trusted for this image.
 // May be "" if unknown.
-func (s *dirImageSource) GetIntendedDockerReference() string {
+func (s *dirImageSource) IntendedDockerReference() string {
 	return ""
 }
 

--- a/docker/docker_image.go
+++ b/docker/docker_image.go
@@ -22,7 +22,7 @@ type dockerImage struct {
 	src              *dockerImageSource
 	digest           string
 	rawManifest      []byte
-	cachedSignatures [][]byte // Private cache for GetSignatures; nil if not yet known.
+	cachedSignatures [][]byte // Private cache for Signatures(); nil if not yet known.
 }
 
 // NewDockerImage returns a new Image interface type after setting up
@@ -42,16 +42,16 @@ func (i *dockerImage) GetIntendedDockerReference() string {
 	return i.src.GetIntendedDockerReference()
 }
 
-// GetManifest is like ImageSource.GetManifest, but the result is cached; it is OK to call this however often you need.
-func (i *dockerImage) GetManifest() ([]byte, error) {
+// Manifest is like ImageSource.GetManifest, but the result is cached; it is OK to call this however often you need.
+func (i *dockerImage) Manifest() ([]byte, error) {
 	if err := i.retrieveRawManifest(); err != nil {
 		return nil, err
 	}
 	return i.rawManifest, nil
 }
 
-// GetSignatures is like ImageSource.GetSignatures, but the result is cached; it is OK to call this however often you need.
-func (i *dockerImage) GetSignatures() ([][]byte, error) {
+// Signatures is like ImageSource.GetSignatures, but the result is cached; it is OK to call this however often you need.
+func (i *dockerImage) Signatures() ([][]byte, error) {
 	if i.cachedSignatures == nil {
 		sigs, err := i.src.GetSignatures()
 		if err != nil {

--- a/docker/docker_image.go
+++ b/docker/docker_image.go
@@ -35,11 +35,11 @@ func NewDockerImage(img, certPath string, tlsVerify bool) (types.Image, error) {
 	return &dockerImage{src: s}, nil
 }
 
-// GetIntendedDockerReference returns the full, unambiguous, Docker reference for this image, _as specified by the user_
+// IntendedDockerReference returns the full, unambiguous, Docker reference for this image, _as specified by the user_
 // (not as the image itself, or its underlying storage, claims).  This can be used e.g. to determine which public keys are trusted for this image.
 // May be "" if unknown.
-func (i *dockerImage) GetIntendedDockerReference() string {
-	return i.src.GetIntendedDockerReference()
+func (i *dockerImage) IntendedDockerReference() string {
+	return i.src.IntendedDockerReference()
 }
 
 // Manifest is like ImageSource.GetManifest, but the result is cached; it is OK to call this however often you need.

--- a/docker/docker_image.go
+++ b/docker/docker_image.go
@@ -62,7 +62,7 @@ func (i *dockerImage) GetSignatures() ([][]byte, error) {
 	return i.cachedSignatures, nil
 }
 
-func (i *dockerImage) Manifest() (types.ImageManifest, error) {
+func (i *dockerImage) Inspect() (types.ImageManifest, error) {
 	// TODO(runcom): unused version param for now, default to docker v2-1
 	m, err := i.getSchema1Manifest()
 	if err != nil {

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -48,10 +48,10 @@ func NewDockerImageSource(img, certPath string, tlsVerify bool) (types.ImageSour
 	return newDockerImageSource(img, certPath, tlsVerify)
 }
 
-// GetIntendedDockerReference returns the full, unambiguous, Docker reference for this image, _as specified by the user_
+// IntendedDockerReference returns the full, unambiguous, Docker reference for this image, _as specified by the user_
 // (not as the image itself, or its underlying storage, claims).  This can be used e.g. to determine which public keys are trusted for this image.
 // May be "" if unknown.
-func (s *dockerImageSource) GetIntendedDockerReference() string {
+func (s *dockerImageSource) IntendedDockerReference() string {
 	return fmt.Sprintf("%s:%s", s.ref.Name(), s.tag)
 }
 

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -186,10 +186,10 @@ func NewOpenshiftImageSource(imageName, certPath string, tlsVerify bool) (types.
 	}, nil
 }
 
-// GetIntendedDockerReference returns the full, unambiguous, Docker reference for this image, _as specified by the user_
+// IntendedDockerReference returns the full, unambiguous, Docker reference for this image, _as specified by the user_
 // (not as the image itself, or its underlying storage, claims).  This can be used e.g. to determine which public keys are trusted for this image.
 // May be "" if unknown.
-func (s *openshiftImageSource) GetIntendedDockerReference() string {
+func (s *openshiftImageSource) IntendedDockerReference() string {
 	return s.client.canonicalDockerReference()
 }
 

--- a/types/types.go
+++ b/types/types.go
@@ -30,10 +30,10 @@ type Repository interface {
 
 // ImageSource is a service, possibly remote (= slow), to download components of a single image.
 type ImageSource interface {
-	// GetIntendedDockerReference returns the full, unambiguous, Docker reference for this image, _as specified by the user_
+	// IntendedDockerReference returns the full, unambiguous, Docker reference for this image, _as specified by the user_
 	// (not as the image itself, or its underlying storage, claims).  This can be used e.g. to determine which public keys are trusted for this image.
 	// May be "" if unknown.
-	GetIntendedDockerReference() string
+	IntendedDockerReference() string
 	// GetManifest returns the image's manifest.  It may use a remote (= slow) service.
 	GetManifest() (manifest []byte, unverifiedCanonicalDigest string, err error)
 	GetLayer(digest string) (io.ReadCloser, error)
@@ -53,10 +53,10 @@ type ImageDestination interface {
 // Image is a Docker image in a repository.
 type Image interface {
 	// ref to repository?
-	// GetIntendedDockerReference returns the full, unambiguous, Docker reference for this image, _as specified by the user_
+	// IntendedDockerReference returns the full, unambiguous, Docker reference for this image, _as specified by the user_
 	// (not as the image itself, or its underlying storage, claims).  This can be used e.g. to determine which public keys are trusted for this image.
 	// May be "" if unknown.
-	GetIntendedDockerReference() string
+	IntendedDockerReference() string
 	// Manifest is like ImageSource.GetManifest, but the result is cached; it is OK to call this however often you need.
 	Manifest() ([]byte, error)
 	// Signatures is like ImageSource.GetSignatures, but the result is cached; it is OK to call this however often you need.

--- a/types/types.go
+++ b/types/types.go
@@ -60,7 +60,7 @@ type Image interface {
 	// GetSignatures is like ImageSource.GetSignatures, but the result is cached; it is OK to call this however often you need.
 	GetSignatures() ([][]byte, error)
 	Layers(layers ...string) error // configure download directory? Call it DownloadLayers?
-	Manifest() (ImageManifest, error)
+	Inspect() (ImageManifest, error)
 	DockerTar() ([]byte, error) // ??? also, configure output directory
 }
 

--- a/types/types.go
+++ b/types/types.go
@@ -34,8 +34,10 @@ type ImageSource interface {
 	// (not as the image itself, or its underlying storage, claims).  This can be used e.g. to determine which public keys are trusted for this image.
 	// May be "" if unknown.
 	GetIntendedDockerReference() string
+	// GetManifest returns the image's manifest.  It may use a remote (= slow) service.
 	GetManifest() (manifest []byte, unverifiedCanonicalDigest string, err error)
 	GetLayer(digest string) (io.ReadCloser, error)
+	// GetSignatures returns the image's signatures.  It may use a remote (= slow) service.
 	GetSignatures() ([][]byte, error)
 }
 
@@ -55,10 +57,10 @@ type Image interface {
 	// (not as the image itself, or its underlying storage, claims).  This can be used e.g. to determine which public keys are trusted for this image.
 	// May be "" if unknown.
 	GetIntendedDockerReference() string
-	// GetManifest is like ImageSource.GetManifest, but the result is cached; it is OK to call this however often you need.
-	GetManifest() ([]byte, error)
-	// GetSignatures is like ImageSource.GetSignatures, but the result is cached; it is OK to call this however often you need.
-	GetSignatures() ([][]byte, error)
+	// Manifest is like ImageSource.GetManifest, but the result is cached; it is OK to call this however often you need.
+	Manifest() ([]byte, error)
+	// Signatures is like ImageSource.GetSignatures, but the result is cached; it is OK to call this however often you need.
+	Signatures() ([][]byte, error)
 	Layers(layers ...string) error // configure download directory? Call it DownloadLayers?
 	Inspect() (ImageManifest, error)
 	DockerTar() ([]byte, error) // ??? also, configure output directory


### PR DESCRIPTION
Per the discussion in #57.