### PR TITLE
[WIP] adapt code and interfaces to MIME types

### DIFF
--- a/cmd/skopeo/copy.go
+++ b/cmd/skopeo/copy.go
@@ -54,7 +54,7 @@ func copyHandler(context *cli.Context) {
 	}
 	signBy := context.String("sign-by")
 
-	manifest, err := src.GetManifest()
+	manifest, _, err := src.GetManifest()
 	if err != nil {
 		logrus.Fatalf("Error reading manifest: %s", err.Error())
 	}

--- a/cmd/skopeo/inspect.go
+++ b/cmd/skopeo/inspect.go
@@ -38,7 +38,7 @@ var inspectCmd = cli.Command{
 		if err != nil {
 			logrus.Fatal(err)
 		}
-		rawManifest, err := img.Manifest()
+		rawManifest, _, err := img.Manifest()
 		if err != nil {
 			logrus.Fatal(err)
 		}

--- a/directory/directory.go
+++ b/directory/directory.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/projectatomic/skopeo/docker/utils"
 	"github.com/projectatomic/skopeo/types"
 )
 
@@ -84,8 +85,13 @@ func (s *dirImageSource) IntendedDockerReference() string {
 	return ""
 }
 
-func (s *dirImageSource) GetManifest() ([]byte, error) {
-	return ioutil.ReadFile(manifestPath(s.dir))
+func (s *dirImageSource) GetManifest() ([]byte, string, error) {
+	m, err := ioutil.ReadFile(manifestPath(s.dir))
+	if err != nil {
+		return nil, "", err
+	}
+	mimeType := utils.GuessManifestMIMEType(m)
+	return m, mimeType, nil
 }
 
 func (s *dirImageSource) GetLayer(digest string) (io.ReadCloser, error) {

--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -78,7 +78,7 @@ func newDockerClient(refHostname, certPath string, tlsVerify bool) (*dockerClien
 	}, nil
 }
 
-func (c *dockerClient) makeRequest(method, url string, headers map[string]string, stream io.Reader) (*http.Response, error) {
+func (c *dockerClient) makeRequest(method, url string, headers map[string][]string, stream io.Reader) (*http.Response, error) {
 	if c.scheme == "" {
 		pr, err := c.ping()
 		if err != nil {
@@ -95,7 +95,9 @@ func (c *dockerClient) makeRequest(method, url string, headers map[string]string
 	}
 	req.Header.Set("Docker-Distribution-API-Version", "registry/2.0")
 	for n, h := range headers {
-		req.Header.Add(n, h)
+		for _, hh := range h {
+			req.Header.Add(n, hh)
+		}
 	}
 	if c.wwwAuthenticate != "" {
 		if err := c.setupRequestAuth(req); err != nil {

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -49,10 +49,10 @@ func (d *dockerImageDestination) PutManifest(manifest []byte) error {
 	}
 	url := fmt.Sprintf(manifestURL, d.ref.RemoteName(), digest)
 
-	headers := map[string]string{}
+	headers := map[string][]string{}
 	mimeType := utils.GuessManifestMIMEType(manifest)
 	if mimeType != "" {
-		headers["Content-Type"] = mimeType
+		headers["Content-Type"] = []string{mimeType}
 	}
 	res, err := d.c.makeRequest("PUT", url, headers, bytes.NewReader(manifest))
 	if err != nil {
@@ -89,7 +89,9 @@ func (d *dockerImageDestination) PutLayer(digest string, stream io.Reader) error
 	uploadURL := fmt.Sprintf(blobUploadURL, d.ref.RemoteName(), digest)
 	logrus.Debugf("Uploading %s", uploadURL)
 	// FIXME: Set Content-Length?
-	res, err = d.c.makeRequest("POST", uploadURL, map[string]string{"Content-Type": "application/octet-stream"}, stream)
+	headers := map[string][]string{}
+	headers["Content-Type"] = []string{"application/octet-stream"}
+	res, err = d.c.makeRequest("POST", uploadURL, headers, stream)
 	if err != nil {
 		return err
 	}

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/projectatomic/skopeo/docker/utils"
 	"github.com/projectatomic/skopeo/reference"
 	"github.com/projectatomic/skopeo/types"
 )
@@ -55,24 +56,26 @@ func (s *dockerImageSource) IntendedDockerReference() string {
 	return fmt.Sprintf("%s:%s", s.ref.Name(), s.tag)
 }
 
-func (s *dockerImageSource) GetManifest() ([]byte, error) {
-	url := fmt.Sprintf(manifestURL, s.ref.RemoteName(), s.tag)
+func (s *dockerImageSource) GetManifest() ([]byte, string, error) {
 	// TODO(runcom) set manifest version header! schema1 for now - then schema2 etc etc and v1
 	// TODO(runcom) NO, switch on the resulter manifest like Docker is doing
-	res, err := s.c.makeRequest("GET", url, nil, nil)
+	url := fmt.Sprintf(manifestURL, s.ref.RemoteName(), s.tag)
+	headers := map[string][]string{}
+	headers["Accept"] = append(headers["Accept"], utils.GetManifestMIMETypes()...)
+	res, err := s.c.makeRequest("GET", url, headers, nil)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	defer res.Body.Close()
 	manblob, err := ioutil.ReadAll(res.Body)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	if res.StatusCode != http.StatusOK {
-		return nil, errFetchManifest{res.StatusCode, manblob}
+		return nil, "", errFetchManifest{res.StatusCode, manblob}
 	}
 	// We might validate manblob against the Docker-Content-Digest header here to protect against transport errors.
-	return manblob, nil
+	return manblob, res.Header.Get("Content-Type"), nil
 }
 
 func (s *dockerImageSource) GetLayer(digest string) (io.ReadCloser, error) {

--- a/docker/utils/fixtures/v2list.manifest.json
+++ b/docker/utils/fixtures/v2list.manifest.json
@@ -1,0 +1,57 @@
+{
+   "schemaVersion": 2,
+   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+   "manifests": [
+      {
+         "mediaType": "application/vnd.docker.distribution.manifest.v1+json",
+         "size": 2094,
+         "digest": "sha256:7820f9a86d4ad15a2c4f0c0e5479298df2aa7c2f6871288e2ef8546f3e7b6783",
+         "platform": {
+            "architecture": "ppc64le",
+            "os": "linux"
+         }
+      },
+      {
+         "mediaType": "application/vnd.docker.distribution.manifest.v1+json",
+         "size": 1922,
+         "digest": "sha256:ae1b0e06e8ade3a11267564a26e750585ba2259c0ecab59ab165ad1af41d1bdd",
+         "platform": {
+            "architecture": "amd64",
+            "os": "linux",
+            "features": [
+               "sse"
+            ]
+         }
+      },
+      {
+         "mediaType": "application/vnd.docker.distribution.manifest.v1+json",
+         "size": 2084,
+         "digest": "sha256:e4c0df75810b953d6717b8f8f28298d73870e8aa2a0d5e77b8391f16fdfbbbe2",
+         "platform": {
+            "architecture": "s390x",
+            "os": "linux"
+         }
+      },
+      {
+         "mediaType": "application/vnd.docker.distribution.manifest.v1+json",
+         "size": 2084,
+         "digest": "sha256:07ebe243465ef4a667b78154ae6c3ea46fdb1582936aac3ac899ea311a701b40",
+         "platform": {
+            "architecture": "arm",
+            "os": "linux",
+            "variant": "armv7"
+         }
+      },
+      {
+         "mediaType": "application/vnd.docker.distribution.manifest.v1+json",
+         "size": 2090,
+         "digest": "sha256:fb2fc0707b86dafa9959fe3d29e66af8787aee4d9a23581714be65db4265ad8a",
+         "platform": {
+            "architecture": "arm64",
+            "os": "linux",
+            "variant": "armv8"
+         }
+      }
+   ]
+}
+

--- a/docker/utils/manifest.go
+++ b/docker/utils/manifest.go
@@ -10,11 +10,22 @@ import (
 
 // FIXME: Should we just use docker/distribution and docker/docker implementations directly?
 
+// GetManifestMIMETypes returns a slice of MIME types we currently support
+func GetManifestMIMETypes() []string {
+	return []string{
+		V2Schema1MIMEType,
+		V2Schema2MIMEType,
+		V2ListMIMEType,
+	}
+}
+
 const (
-	// DockerV2Schema1MIMEType MIME type represents Docker manifest schema 1
-	DockerV2Schema1MIMEType = "application/vnd.docker.distribution.manifest.v1+json"
-	// DockerV2Schema2MIMEType MIME type represents Docker manifest schema 2
-	DockerV2Schema2MIMEType = "application/vnd.docker.distribution.manifest.v2+json"
+	// V2Schema1MIMEType MIME type represents Docker manifest schema 1
+	V2Schema1MIMEType = "application/vnd.docker.distribution.manifest.v1+json"
+	// V2Schema2MIMEType MIME type represents Docker manifest schema 2
+	V2Schema2MIMEType = "application/vnd.docker.distribution.manifest.v2+json"
+	// V2ListMIMEType MIME type represents Docker *fat* manifest aka manifest list
+	V2ListMIMEType = "application/vnd.docker.distribution.manifest.list.v2+json"
 )
 
 // GuessManifestMIMEType guesses MIME type of a manifest and returns it _if it is recognized_, or "" if unknown or unrecognized.
@@ -32,21 +43,21 @@ func GuessManifestMIMEType(manifest []byte) string {
 	}
 
 	switch meta.MediaType {
-	case DockerV2Schema2MIMEType: // A recognized type.
+	case V2Schema2MIMEType, V2ListMIMEType: // A recognized type.
 		return meta.MediaType
 	}
 	switch meta.SchemaVersion {
 	case 1:
-		return DockerV2Schema1MIMEType
+		return V2Schema1MIMEType
 	case 2: // Really should not happen, meta.MediaType should have been set. But given the data, this is our best guess.
-		return DockerV2Schema2MIMEType
+		return V2Schema2MIMEType
 	}
 	return ""
 }
 
 // ManifestDigest returns the a digest of a docker manifest, with any necessary implied transformations like stripping v1s1 signatures.
 func ManifestDigest(manifest []byte) (string, error) {
-	if GuessManifestMIMEType(manifest) == DockerV2Schema1MIMEType {
+	if GuessManifestMIMEType(manifest) == V2Schema1MIMEType {
 		sig, err := libtrust.ParsePrettySignature(manifest, "signatures")
 		if err != nil {
 			return "", err

--- a/docker/utils/manifest_test.go
+++ b/docker/utils/manifest_test.go
@@ -14,10 +14,11 @@ func TestGuessManifestMIMEType(t *testing.T) {
 		path     string
 		mimeType string
 	}{
-		{"v2s2.manifest.json", DockerV2Schema2MIMEType},
-		{"v2s1.manifest.json", DockerV2Schema1MIMEType},
-		{"v2s1-invalid-signatures.manifest.json", DockerV2Schema1MIMEType},
-		{"v2s2nomime.manifest.json", DockerV2Schema2MIMEType}, // It is unclear whether this one is legal, but we should guess v2s2 if anything at all.
+		{"v2s2.manifest.json", V2Schema2MIMEType},
+		{"v2list.manifest.json", V2ListMIMEType},
+		{"v2s1.manifest.json", V2Schema1MIMEType},
+		{"v2s1-invalid-signatures.manifest.json", V2Schema1MIMEType},
+		{"v2s2nomime.manifest.json", V2Schema2MIMEType}, // It is unclear whether this one is legal, but we should guess v2s2 if anything at all.
 		{"unknown-version.manifest.json", ""},
 		{"non-json.manifest.json", ""}, // Not a manifest (nor JSON) at all
 	}

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -193,9 +193,9 @@ func (s *openshiftImageSource) IntendedDockerReference() string {
 	return s.client.canonicalDockerReference()
 }
 
-func (s *openshiftImageSource) GetManifest() ([]byte, error) {
+func (s *openshiftImageSource) GetManifest() ([]byte, string, error) {
 	if err := s.ensureImageIsResolved(); err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	return s.docker.GetManifest()
 }

--- a/types/types.go
+++ b/types/types.go
@@ -38,7 +38,7 @@ type ImageSource interface {
 	IntendedDockerReference() string
 	// GetManifest returns the image's manifest.  It may use a remote (= slow) service.
 	// FIXME? This should also return a MIME type if known, to differentiate between schema versions.
-	GetManifest() ([]byte, error)
+	GetManifest() ([]byte, string, error)
 	// Note: Calling GetLayer() may have ordering dependencies WRT other methods of this type. FIXME: How does this work with (docker save) on stdin?
 	GetLayer(digest string) (io.ReadCloser, error)
 	// GetSignatures returns the image's signatures.  It may use a remote (= slow) service.
@@ -65,7 +65,7 @@ type Image interface {
 	IntendedDockerReference() string
 	// Manifest is like ImageSource.GetManifest, but the result is cached; it is OK to call this however often you need.
 	// FIXME? This should also return a MIME type if known, to differentiate between schema versions.
-	Manifest() ([]byte, error)
+	Manifest() ([]byte, string, error)
 	// Signatures is like ImageSource.GetSignatures, but the result is cached; it is OK to call this however often you need.
 	Signatures() ([][]byte, error)
 	Layers(layers ...string) error // configure download directory? Call it DownloadLayers?


### PR DESCRIPTION
This is a WIP to support more MIME types when fetching manifests - in particular this aims to provide support for manifest list (from Docker) -> see https://integratedcode.us/2016/04/22/a-step-towards-multi-platform-docker-images/ (I personally want this here in skopeo :))

@mtrmac PTAL

- First commit just adapts code to ask/use/retrieve MIME types (and breaks `inspect` command :smile: till we do the point below)
- TODO: choose v2s1 to maintain backcompatibility -> this means when asking for a manifest we should also provide the mime type we would like to have back (falling back to a default if anything's wrong) **OR** we can do the manifestlist->v2s1 conversion when needed (cmd/skopeo/inspect)
- TODO: command line

Signed-off-by: Antonio Murdaca <runcom@redhat.com>