### PR TITLE
remove logging from libraries and cleanup

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -12,7 +12,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/homedir"
 )
 
@@ -108,7 +107,6 @@ func (c *dockerClient) makeRequest(method, url string, headers map[string][]stri
 	if c.transport != nil {
 		client.Transport = c.transport
 	}
-	logrus.Debugf("%s %s", method, url)
 	res, err := client.Do(req)
 	if err != nil {
 		return nil, err
@@ -293,12 +291,10 @@ func (c *dockerClient) ping() (*pingResponse, error) {
 	ping := func(scheme string) (*pingResponse, error) {
 		url := fmt.Sprintf(baseURL, scheme, c.registry)
 		resp, err := client.Get(url)
-		logrus.Debugf("Ping %s err %#v", url, err)
 		if err != nil {
 			return nil, err
 		}
 		defer resp.Body.Close()
-		logrus.Debugf("Ping %s status %d", scheme+"://"+c.registry+"/v2/", resp.StatusCode)
 		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusUnauthorized {
 			return nil, fmt.Errorf("error pinging repository, response code %d", resp.StatusCode)
 		}

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/projectatomic/skopeo/docker/utils"
 	"github.com/projectatomic/skopeo/reference"
 	"github.com/projectatomic/skopeo/types"
 )
@@ -55,6 +55,15 @@ func (s *dockerImageSource) IntendedDockerReference() string {
 	return fmt.Sprintf("%s:%s", s.ref.Name(), s.tag)
 }
 
+// ManifestMIMETypes returns a slice of supported MIME types
+func manifestMIMETypes() []string {
+	return []string{
+		utils.DockerV2Schema1MIMEType,
+		utils.DockerV2Schema2MIMEType,
+		utils.DockerV2ListMIMEType,
+	}
+}
+
 func (s *dockerImageSource) GetManifest() ([]byte, string, error) {
 	url := fmt.Sprintf(manifestURL, s.ref.RemoteName(), s.tag)
 	// TODO(runcom) set manifest version header! schema1 for now - then schema2 etc etc and v1
@@ -77,7 +86,6 @@ func (s *dockerImageSource) GetManifest() ([]byte, string, error) {
 
 func (s *dockerImageSource) GetLayer(digest string) (io.ReadCloser, error) {
 	url := fmt.Sprintf(blobsURL, s.ref.RemoteName(), digest)
-	logrus.Infof("Downloading %s", url)
 	res, err := s.c.makeRequest("GET", url, nil, nil)
 	if err != nil {
 		return nil, err

--- a/docker/utils/manifest.go
+++ b/docker/utils/manifest.go
@@ -10,15 +10,6 @@ import (
 
 // FIXME: Should we just use docker/distribution and docker/docker implementations directly?
 
-// ManifestMIMETypes returns a slice of supported MIME types
-func ManifestMIMETypes() []string {
-	return []string{
-		DockerV2Schema1MIMEType,
-		DockerV2Schema2MIMEType,
-		DockerV2ListMIMEType,
-	}
-}
-
 const (
 	// DockerV2Schema1MIMEType MIME type represents Docker manifest schema 1
 	DockerV2Schema1MIMEType = "application/vnd.docker.distribution.manifest.v1+json"


### PR DESCRIPTION
Logging inside libraries/pkgs is ugly - callers should log instead.
Also, move `ManifestMIMETypes` directly into `docker_img_src` where it will be later used (and un-export it, no need to have this in the API, the const(s) suffice)

@mtrmac PTAL

Signed-off-by: Antonio Murdaca <runcom@redhat.com>