### PR TITLE
add the possibility to choose image's MIME type

### DIFF
--- a/cmd/skopeo/copy.go
+++ b/cmd/skopeo/copy.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
+	"github.com/projectatomic/skopeo/docker/utils"
 	"github.com/projectatomic/skopeo/signature"
 )
 
@@ -54,7 +55,7 @@ func copyHandler(context *cli.Context) {
 	}
 	signBy := context.String("sign-by")
 
-	manifest, _, err := src.GetManifest()
+	manifest, _, err := src.GetManifest([]string{utils.DockerV2Schema1MIMEType})
 	if err != nil {
 		logrus.Fatalf("Error reading manifest: %s", err.Error())
 	}

--- a/directory/directory.go
+++ b/directory/directory.go
@@ -85,7 +85,7 @@ func (s *dirImageSource) IntendedDockerReference() string {
 }
 
 // it's up to the caller to determine the MIME type of the returned manifest's bytes
-func (s *dirImageSource) GetManifest() ([]byte, string, error) {
+func (s *dirImageSource) GetManifest(_ []string) ([]byte, string, error) {
 	m, err := ioutil.ReadFile(manifestPath(s.dir))
 	if err != nil {
 		return nil, "", err

--- a/docker/docker_image.go
+++ b/docker/docker_image.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/projectatomic/skopeo/directory"
+	"github.com/projectatomic/skopeo/docker/utils"
 	"github.com/projectatomic/skopeo/types"
 )
 
@@ -44,7 +45,7 @@ func (i *dockerImage) IntendedDockerReference() string {
 // Manifest is like ImageSource.GetManifest, but the result is cached; it is OK to call this however often you need.
 func (i *dockerImage) Manifest() ([]byte, error) {
 	if i.cachedManifest == nil {
-		m, _, err := i.src.GetManifest()
+		m, _, err := i.src.GetManifest([]string{utils.DockerV2Schema1MIMEType})
 		if err != nil {
 			return nil, err
 		}

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -55,11 +55,13 @@ func (s *dockerImageSource) IntendedDockerReference() string {
 	return fmt.Sprintf("%s:%s", s.ref.Name(), s.tag)
 }
 
-func (s *dockerImageSource) GetManifest() ([]byte, string, error) {
+func (s *dockerImageSource) GetManifest(mimetypes []string) ([]byte, string, error) {
 	url := fmt.Sprintf(manifestURL, s.ref.RemoteName(), s.tag)
 	// TODO(runcom) set manifest version header! schema1 for now - then schema2 etc etc and v1
 	// TODO(runcom) NO, switch on the resulter manifest like Docker is doing
-	res, err := s.c.makeRequest("GET", url, nil, nil)
+	headers := make(map[string][]string)
+	headers["Accept"] = mimetypes
+	res, err := s.c.makeRequest("GET", url, headers, nil)
 	if err != nil {
 		return nil, "", err
 	}

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -193,11 +193,11 @@ func (s *openshiftImageSource) IntendedDockerReference() string {
 	return s.client.canonicalDockerReference()
 }
 
-func (s *openshiftImageSource) GetManifest() ([]byte, string, error) {
+func (s *openshiftImageSource) GetManifest(mimetypes []string) ([]byte, string, error) {
 	if err := s.ensureImageIsResolved(); err != nil {
 		return nil, "", err
 	}
-	return s.docker.GetManifest()
+	return s.docker.GetManifest(mimetypes)
 }
 
 func (s *openshiftImageSource) GetLayer(digest string) (io.ReadCloser, error) {

--- a/types/types.go
+++ b/types/types.go
@@ -27,8 +27,9 @@ type ImageSource interface {
 	// (not as the image itself, or its underlying storage, claims).  This can be used e.g. to determine which public keys are trusted for this image.
 	// May be "" if unknown.
 	IntendedDockerReference() string
-	// GetManifest returns the image's manifest along with its MIME type. The empty string is returned if the MIME type is unknown.  It may use a remote (= slow) service.
-	GetManifest() ([]byte, string, error)
+	// GetManifest returns the image's manifest along with its MIME type. The empty string is returned if the MIME type is unknown. The slice parameter indicates the supported mime types the manifest should be when getting it.
+	// It may use a remote (= slow) service.
+	GetManifest([]string) ([]byte, string, error)
 	// Note: Calling GetLayer() may have ordering dependencies WRT other methods of this type. FIXME: How does this work with (docker save) on stdin?
 	GetLayer(digest string) (io.ReadCloser, error)
 	// GetSignatures returns the image's signatures.  It may use a remote (= slow) service.


### PR DESCRIPTION
This is tough, but as a user of skopeo libraries/pkgs I wish to be able to provide a list of mime types which I wish to get back (in order). Then I can check the returned mime type to understand it.

@mtrmac PTAL

Signed-off-by: Antonio Murdaca <runcom@redhat.com>