### PR TITLE
Card container_security_113 - Delete image support

### DIFF
--- a/cmd/skopeo/delete.go
+++ b/cmd/skopeo/delete.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"github.com/Sirupsen/logrus"
+	"github.com/codegangsta/cli"
+)
+
+func deleteHandler(context *cli.Context) {
+	if len(context.Args()) != 1 {
+		logrus.Fatal("Usage: delete imageReference")
+	}
+
+	image, err := parseImageSource(context, context.Args()[0])
+	if err != nil {
+		logrus.Fatal(err.Error())
+	}
+
+	if err := image.Delete(); err != nil {
+		logrus.Fatal(err)
+	}
+}
+
+var deleteCmd = cli.Command{
+	Name:   "delete",
+	Usage:  "Delete given image",
+	Action: deleteHandler,
+}

--- a/cmd/skopeo/main.go
+++ b/cmd/skopeo/main.go
@@ -63,6 +63,7 @@ func main() {
 		copyCmd,
 		inspectCmd,
 		layersCmd,
+		deleteCmd,
 		standaloneSignCmd,
 		standaloneVerifyCmd,
 	}

--- a/directory/directory.go
+++ b/directory/directory.go
@@ -111,3 +111,7 @@ func (s *dirImageSource) GetSignatures() ([][]byte, error) {
 	}
 	return signatures, nil
 }
+
+func (s *dirImageSource) Delete() error {
+	return fmt.Errorf("directory#dirImageSource.Delete() not implmented")
+}

--- a/man1/skopeo.1
+++ b/man1/skopeo.1
@@ -10,6 +10,8 @@ skopeo \(em Inspect Docker images and repositories on registries
 .SH SYNOPSIS
 \fBskopeo copy\fR [\fB--sign-by=\fRkey-ID] source-location destination-location
 .PP
+\fBskopeo delete\fR source-location
+.PP
 \fBskopeo inspect\fR image-name [\fB--raw\fR]
 .PP
 \fBskopeo layers\fR image-name
@@ -54,11 +56,21 @@ Copy an image (manifest, filesystem layers, signatures) from one location to ano
 .B source-location
 and
 .B destination-location
-can be \fBdocker://\fRdocker-reference, \fBdir:\fRlocal-path, or \fBatomic:\fRimagestream-name\fB:\fRtag .
+can be \fB\%docker://\fRdocker-reference, \fBdir:\fRlocal-path, or \fBatomic:\fRimagestream-name\fB:\fRtag .
 .sp
 \fB\-\-sign\-by=\fRkey-id
 Add a signature by the specified key ID for image name corresponding to \fBdestination-location\fR.
 Existing signatures, if any, are preserved as well.
+.TP
+.B delete
+Mark an image for deletion.  You must then run docker registry garabage collection to recover the disk space. E.g.,
+.sp
+\fBdocker exec -it registry bin/registry \\
+.br
+garbage-collect /etc/docker/registry/config.yml\fR
+.sp 2
+Additionally, the registry must allow deletions by setting \fB\%REGISTRY_STORAGE_DELETE_ENABLED=true\fR
+for the registry daemon.
 .TP
 .B inspect
 Return low-level information on images in a registry

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -396,3 +396,7 @@ type status struct {
 	// Details *StatusDetails `json:"details,omitempty"`
 	Code int32 `json:"code,omitempty"`
 }
+
+func (s *openshiftImageSource) Delete() error {
+	return fmt.Errorf("openshift#openshiftImageSource.Delete() not implmented")
+}

--- a/types/types.go
+++ b/types/types.go
@@ -33,6 +33,8 @@ type ImageSource interface {
 	GetLayer(digest string) (io.ReadCloser, error)
 	// GetSignatures returns the image's signatures.  It may use a remote (= slow) service.
 	GetSignatures() ([][]byte, error)
+	// Delete image from registry, if operation is supported
+	Delete() error
 }
 
 // ImageDestination is a service, possibly remote (= slow), to store components of a single image.


### PR DESCRIPTION
Add support to mark images for deletion from repository

Requires:
  * V2 API and schema
  * registry configured to allow deletes
  * run registry garbage collection to free up disk space

Signed-off-by: Jhon Honce <jhonce@redhat.com>