### PR TITLE
Move docker.genericImage to a separate skopeo/image subpackage

### DIFF
--- a/cmd/skopeo/inspect.go
+++ b/cmd/skopeo/inspect.go
@@ -68,10 +68,7 @@ var inspectCmd = cli.Command{
 			logrus.Fatalf("Error computing manifest digest: %s", err.Error())
 		}
 		if dockerImg, ok := img.(*docker.Image); ok {
-			outputData.Name, err = dockerImg.SourceRefFullName()
-			if err != nil {
-				logrus.Fatalf("Error getting expanded repository name: %s", err.Error())
-			}
+			outputData.Name = dockerImg.SourceRefFullName()
 			outputData.RepoTags, err = dockerImg.GetRepositoryTags()
 			if err != nil {
 				logrus.Fatalf("Error determining repository tags: %s", err.Error())

--- a/cmd/skopeo/utils.go
+++ b/cmd/skopeo/utils.go
@@ -7,6 +7,7 @@ import (
 	"github.com/codegangsta/cli"
 	"github.com/projectatomic/skopeo/directory"
 	"github.com/projectatomic/skopeo/docker"
+	"github.com/projectatomic/skopeo/image"
 	"github.com/projectatomic/skopeo/openshift"
 	"github.com/projectatomic/skopeo/types"
 )
@@ -34,7 +35,7 @@ func parseImage(c *cli.Context) (types.Image, error) {
 		//
 	case strings.HasPrefix(imgName, directoryPrefix):
 		src := directory.NewDirImageSource(strings.TrimPrefix(imgName, directoryPrefix))
-		return docker.GenericImageFromSource(src), nil
+		return image.FromSource(src), nil
 	}
 	return nil, fmt.Errorf("no valid prefix provided")
 }

--- a/docker/docker_image.go
+++ b/docker/docker_image.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/projectatomic/skopeo/image"
 	"github.com/projectatomic/skopeo/types"
 )
 
@@ -22,7 +23,7 @@ func NewDockerImage(img, certPath string, tlsVerify bool) (types.Image, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Image{Image: GenericImageFromSource(s), src: s}, nil
+	return &Image{Image: image.FromSource(s), src: s}, nil
 }
 
 // SourceRefFullName returns a fully expanded name for the repository this image is in.

--- a/docker/docker_image.go
+++ b/docker/docker_image.go
@@ -11,7 +11,8 @@ import (
 // Image is a Docker-specific implementation of types.Image with a few extra methods
 // which are specific to Docker.
 type Image struct {
-	genericImage
+	types.Image
+	src *dockerImageSource
 }
 
 // NewDockerImage returns a new Image interface type after setting up
@@ -21,35 +22,18 @@ func NewDockerImage(img, certPath string, tlsVerify bool) (types.Image, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Image{genericImage{src: s}}, nil
-}
-
-// By construction a, docker.Image.genericImage.src must be a dockerImageSource.
-// dockerSource returns it.
-func (i *Image) dockerSource() (*dockerImageSource, error) {
-	if src, ok := i.genericImage.src.(*dockerImageSource); ok {
-		return src, nil
-	}
-	return nil, fmt.Errorf("Unexpected internal inconsistency, docker.Image not based on dockerImageSource")
+	return &Image{Image: GenericImageFromSource(s), src: s}, nil
 }
 
 // SourceRefFullName returns a fully expanded name for the repository this image is in.
-func (i *Image) SourceRefFullName() (string, error) {
-	src, err := i.dockerSource()
-	if err != nil {
-		return "", err
-	}
-	return src.ref.FullName(), nil
+func (i *Image) SourceRefFullName() string {
+	return i.src.ref.FullName()
 }
 
 // GetRepositoryTags list all tags available in the repository. Note that this has no connection with the tag(s) used for this specific image, if any.
 func (i *Image) GetRepositoryTags() ([]string, error) {
-	src, err := i.dockerSource()
-	if err != nil {
-		return nil, err
-	}
-	url := fmt.Sprintf(tagsURL, src.ref.RemoteName())
-	res, err := src.c.makeRequest("GET", url, nil, nil)
+	url := fmt.Sprintf(tagsURL, i.src.ref.RemoteName())
+	res, err := i.src.c.makeRequest("GET", url, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/image/image.go
+++ b/image/image.go
@@ -1,4 +1,7 @@
-package docker
+// Package image consolidates knowledge about various container image formats
+// (as opposed to image storage mechanisms, which are handled by types.ImageSource)
+// and exposes all of them using an unified interface.
+package image
 
 import (
 	"encoding/json"
@@ -20,17 +23,17 @@ var (
 
 // genericImage is a general set of utilities for working with container images,
 // whatever is their underlying location (i.e. dockerImageSource-independent).
+// Note the existence of skopeo/docker.Image: some instances of a `types.Image`
+// may not be a `genericImage` directly. However, most users of `types.Image`
+// do not care, and those who care about `skopeo/docker.Image` know they do.
 type genericImage struct {
 	src              types.ImageSource
 	cachedManifest   []byte   // Private cache for Manifest(); nil if not yet known.
 	cachedSignatures [][]byte // Private cache for Signatures(); nil if not yet known.
 }
 
-// GenericImageFromSource returns a types.Image implementation for source.
-// NOTE: This is currently an internal testing helper, do not rely on this as
-// a stable API. There might be an ImageFromSource eventually, but it would not be
-// in the skopeo/docker package.
-func GenericImageFromSource(src types.ImageSource) types.Image {
+// FromSource returns a types.Image implementation for source.
+func FromSource(src types.ImageSource) types.Image {
 	return &genericImage{src: src}
 }
 

--- a/signature/policy_eval_signedby_test.go
+++ b/signature/policy_eval_signedby_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/projectatomic/skopeo/directory"
-	"github.com/projectatomic/skopeo/docker"
+	"github.com/projectatomic/skopeo/image"
 	"github.com/projectatomic/skopeo/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -15,7 +15,7 @@ import (
 
 // dirImageMock returns a types.Image for a directory, claiming a specified intendedDockerReference.
 func dirImageMock(dir, intendedDockerReference string) types.Image {
-	return docker.GenericImageFromSource(&dirImageSourceMock{
+	return image.FromSource(&dirImageSourceMock{
 		ImageSource:             directory.NewDirImageSource(dir),
 		intendedDockerReference: intendedDockerReference,
 	})


### PR DESCRIPTION
Signature verification in `skopeo --policy … copy` requires a `types.Image`, making `docker.GenericImageFromSource` increasingly awkward. Clean this up by moving the `genericImage` code into a separate `skopeo/image` subpackage.

See individual commits for more detailed comments.