### PR TITLE
Generalize [Get|Put]Layer

### DIFF
--- a/cmd/skopeo/copy.go
+++ b/cmd/skopeo/copy.go
@@ -65,12 +65,12 @@ func copyHandler(context *cli.Context) {
 		logrus.Fatalf("Error parsing manifest: %s", err.Error())
 	}
 	for _, layer := range layers {
-		stream, err := src.GetLayer(layer)
+		stream, err := src.GetBlob(layer)
 		if err != nil {
 			logrus.Fatalf("Error reading layer %s: %s", layer, err.Error())
 		}
 		defer stream.Close()
-		if err := dest.PutLayer(layer, stream); err != nil {
+		if err := dest.PutBlob(layer, stream); err != nil {
 			logrus.Fatalf("Error writing layer: %s", err.Error())
 		}
 	}
@@ -101,7 +101,7 @@ func copyHandler(context *cli.Context) {
 		logrus.Fatalf("Error writing signatures: %s", err.Error())
 	}
 
-	// FIXME: We need to call PutManifest after PutLayer and PutSignatures. This seems ugly; move to a "set properties" + "commit" model?
+	// FIXME: We need to call PutManifest after PutBlob and PutSignatures. This seems ugly; move to a "set properties" + "commit" model?
 	if err := dest.PutManifest(manifest); err != nil {
 		logrus.Fatalf("Error writing manifest: %s", err.Error())
 	}

--- a/directory/directory.go
+++ b/directory/directory.go
@@ -44,7 +44,7 @@ func (d *dirImageDestination) PutManifest(manifest []byte) error {
 	return ioutil.WriteFile(manifestPath(d.dir), manifest, 0644)
 }
 
-func (d *dirImageDestination) PutLayer(digest string, stream io.Reader) error {
+func (d *dirImageDestination) PutBlob(digest string, stream io.Reader) error {
 	layerFile, err := os.Create(layerPath(d.dir, digest))
 	if err != nil {
 		return err
@@ -93,7 +93,7 @@ func (s *dirImageSource) GetManifest(_ []string) ([]byte, string, error) {
 	return m, "", err
 }
 
-func (s *dirImageSource) GetLayer(digest string) (io.ReadCloser, error) {
+func (s *dirImageSource) GetBlob(digest string) (io.ReadCloser, error) {
 	return os.Open(layerPath(s.dir, digest))
 }
 

--- a/docker/docker_image_dest.go
+++ b/docker/docker_image_dest.go
@@ -70,7 +70,7 @@ func (d *dockerImageDestination) PutManifest(manifest []byte) error {
 	return nil
 }
 
-func (d *dockerImageDestination) PutLayer(digest string, stream io.Reader) error {
+func (d *dockerImageDestination) PutBlob(digest string, stream io.Reader) error {
 	checkURL := fmt.Sprintf(blobsURL, d.ref.RemoteName(), digest)
 
 	logrus.Debugf("Checking %s", checkURL)

--- a/docker/docker_image_src.go
+++ b/docker/docker_image_src.go
@@ -78,7 +78,7 @@ func (s *dockerImageSource) GetManifest(mimetypes []string) ([]byte, string, err
 	return manblob, res.Header.Get("Content-Type"), nil
 }
 
-func (s *dockerImageSource) GetLayer(digest string) (io.ReadCloser, error) {
+func (s *dockerImageSource) GetBlob(digest string) (io.ReadCloser, error) {
 	url := fmt.Sprintf(blobsURL, s.ref.RemoteName(), digest)
 	logrus.Infof("Downloading %s", url)
 	res, err := s.c.makeRequest("GET", url, nil, nil)

--- a/image/image.go
+++ b/image/image.go
@@ -204,12 +204,12 @@ func (i *genericImage) Layers(layers ...string) error {
 }
 
 func (i *genericImage) getLayer(dest types.ImageDestination, digest string) error {
-	stream, err := i.src.GetLayer(digest)
+	stream, err := i.src.GetBlob(digest)
 	if err != nil {
 		return err
 	}
 	defer stream.Close()
-	return dest.PutLayer(digest, stream)
+	return dest.PutBlob(digest, stream)
 }
 
 // fixManifestLayers, after validating the supplied manifest

--- a/openshift/openshift.go
+++ b/openshift/openshift.go
@@ -200,11 +200,11 @@ func (s *openshiftImageSource) GetManifest(mimetypes []string) ([]byte, string, 
 	return s.docker.GetManifest(mimetypes)
 }
 
-func (s *openshiftImageSource) GetLayer(digest string) (io.ReadCloser, error) {
+func (s *openshiftImageSource) GetBlob(digest string) (io.ReadCloser, error) {
 	if err := s.ensureImageIsResolved(); err != nil {
 		return nil, err
 	}
-	return s.docker.GetLayer(digest)
+	return s.docker.GetBlob(digest)
 }
 
 func (s *openshiftImageSource) GetSignatures() ([][]byte, error) {
@@ -328,8 +328,8 @@ func (d *openshiftImageDestination) PutManifest(manifest []byte) error {
 	return d.docker.PutManifest(manifest)
 }
 
-func (d *openshiftImageDestination) PutLayer(digest string, stream io.Reader) error {
-	return d.docker.PutLayer(digest, stream)
+func (d *openshiftImageDestination) PutBlob(digest string, stream io.Reader) error {
+	return d.docker.PutBlob(digest, stream)
 }
 
 func (d *openshiftImageDestination) PutSignatures(signatures [][]byte) error {

--- a/types/types.go
+++ b/types/types.go
@@ -29,8 +29,8 @@ type ImageSource interface {
 	// GetManifest returns the image's manifest along with its MIME type. The empty string is returned if the MIME type is unknown. The slice parameter indicates the supported mime types the manifest should be when getting it.
 	// It may use a remote (= slow) service.
 	GetManifest([]string) ([]byte, string, error)
-	// Note: Calling GetLayer() may have ordering dependencies WRT other methods of this type. FIXME: How does this work with (docker save) on stdin?
-	GetLayer(digest string) (io.ReadCloser, error)
+	// Note: Calling GetBlob() may have ordering dependencies WRT other methods of this type. FIXME: How does this work with (docker save) on stdin?
+	GetBlob(digest string) (io.ReadCloser, error)
 	// GetSignatures returns the image's signatures.  It may use a remote (= slow) service.
 	GetSignatures() ([][]byte, error)
 	// Delete image from registry, if operation is supported
@@ -43,8 +43,8 @@ type ImageDestination interface {
 	CanonicalDockerReference() (string, error)
 	// FIXME? This should also receive a MIME type if known, to differentiate between schema versions.
 	PutManifest([]byte) error
-	// Note: Calling PutLayer() and other methods may have ordering dependencies WRT other methods of this type. FIXME: Figure out and document.
-	PutLayer(digest string, stream io.Reader) error
+	// Note: Calling PutBlob() and other methods may have ordering dependencies WRT other methods of this type. FIXME: Figure out and document.
+	PutBlob(digest string, stream io.Reader) error
 	PutSignatures(signatures [][]byte) error
 }
 


### PR DESCRIPTION
preparation for https://trello.com/c/hhK1klNW/143-skopeo-pull-from-docker-and-convert-to-oci

This is actually needed because to convert to OCI image's manifest we also need to fetch the *config* from a v2s2 manifest which is referenced just a normal blob