### PR TITLE
Remove /skopeo.1 from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /skopeo
-/skopeo.1
 /layers-*


### PR DESCRIPTION
`/skopeo.1` was a generated file before #35; now this path is not used (replaced by `man1/skopeo.1`); if the generated file is left around, it is obsolete (and confusingly empty).  Remove it from `.gitignore` to nudge developers like me to clean up.