### PR TITLE
Build binary in a docker container

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,5 @@
+FROM ubuntu:16.04
+RUN apt-get update
+RUN apt-get install -y golang git-core libgpgme11-dev
+ENV GOPATH=/
+WORKDIR /src/github.com/projectatomic/skopeo

--- a/hack/make/test-integration
+++ b/hack/make/test-integration
@@ -8,7 +8,7 @@ bundle_test_integration() {
 
 # subshell so that we can export PATH without breaking other things
 (
-	make binary
+	make binary-local
 	make install-binary
 	export GO15VENDOREXPERIMENT=1
 	bundle_test_integration


### PR DESCRIPTION
so that people don't need to install all dependencies just to build.

Make it so that "make binary" does nothing if nothing changed.

Also use ${DEST} in a few more spots for consistency

Signed-off-by: Doug Davis <dug@us.ibm.com>