### PR TITLE
signature: docker: fix govet in sprintf

### DIFF
--- a/signature/docker.go
+++ b/signature/docker.go
@@ -48,7 +48,7 @@ func VerifyDockerManifestSignature(unverifiedSignature, unverifiedManifest []byt
 				return err
 			}
 			if !matches {
-				return InvalidSignatureError{msg: fmt.Sprintf("Signature for docker digest %s does not match", signedDockerManifestDigest, signedDockerManifestDigest)}
+				return InvalidSignatureError{msg: fmt.Sprintf("Signature for docker digest %q does not match", signedDockerManifestDigest)}
 			}
 			return nil
 		},


### PR DESCRIPTION
```
go vet ./...
signature/docker.go:51: wrong number of args for format in Sprintf call: 1 needed but 2 args
```
I don't know how this went past the go vet check

Signed-off-by: Antonio Murdaca <runcom@redhat.com>