### PR TITLE
cmd: skopeo: fix version

### DIFF
--- a/cmd/skopeo/main.go
+++ b/cmd/skopeo/main.go
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/containers/image/version"
+	"github.com/projectatomic/skopeo/version"
 	"github.com/urfave/cli"
 )
 

--- a/integration/check_test.go
+++ b/integration/check_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/go-check/check"
+	"github.com/projectatomic/skopeo/version"
 )
 
 const (
@@ -70,7 +71,7 @@ func (s *SkopeoSuite) TearDownTest(c *check.C) {
 //func skopeoCmd()
 
 func (s *SkopeoSuite) TestVersion(c *check.C) {
-	wanted := fmt.Sprintf(".*%s version .*", skopeoBinary)
+	wanted := fmt.Sprintf(".*%s version %s .*", skopeoBinary, version.Version)
 	assertSkopeoSucceeds(c, wanted, "--version")
 }
 


### PR DESCRIPTION
Clearly wrong (from containers/image):
```bash
# wrong
$./skopeo --version
skopeo version 0.1.0-dev commit: 6d7c93acf7bc380d5c0c51aa0a5788cc99810df0

# fixed
$ ./skopeo --version
skopeo version 0.1.14-dev commit: 6d7c93acf7bc380d5c0c51aa0a5788cc99810df0
```

Signed-off-by: Antonio Murdaca <runcom@redhat.com>