### PR TITLE
Fix integration tests on CentOS

### DIFF
--- a/integration/check_test.go
+++ b/integration/check_test.go
@@ -71,7 +71,7 @@ func (s *SkopeoSuite) TearDownTest(c *check.C) {
 //func skopeoCmd()
 
 func (s *SkopeoSuite) TestVersion(c *check.C) {
-	wanted := fmt.Sprintf(".*%s version %s .*", skopeoBinary, version.Version)
+	wanted := fmt.Sprintf(".*%s version %s.*", skopeoBinary, version.Version)
 	assertSkopeoSucceeds(c, wanted, "--version")
 }
 


### PR DESCRIPTION
This fixes `--version` integration test on CentOS, as noticed by https://github.com/projectatomic/skopeo/pull/91 .  The underlying cause is:

- `Makefile` builds with `-ldflags "-X var=value"`, while go 1.4.2 only supports `"-X var value"`.  This  auses CentOS builds to be built without the specific commit information
- The `--version` integration test assumes that commit information will always follow the version number.

Changing either one of these would fix the build, changing the integration test has the advantage that we don't have to use the obsolete `-X` syntax and suffer warnings on newer Go versions.