### PR TITLE
Clean up Docker reference handling

### DIFF
--- a/cmd/skopeo/copy.go
+++ b/cmd/skopeo/copy.go
@@ -58,12 +58,12 @@ func copyHandler(context *cli.Context) error {
 		if err != nil {
 			return fmt.Errorf("Error initializing GPG: %v", err)
 		}
-		dockerReference, err := dest.CanonicalDockerReference()
-		if err != nil {
-			return fmt.Errorf("Error determining canonical Docker reference: %v", err)
+		dockerReference := dest.CanonicalDockerReference()
+		if dockerReference == nil {
+			return errors.New("Destination image does not have an associated Docker reference")
 		}
 
-		newSig, err := signature.SignDockerManifest(manifest, dockerReference, mech, signBy)
+		newSig, err := signature.SignDockerManifest(manifest, dockerReference.String(), mech, signBy)
 		if err != nil {
 			return fmt.Errorf("Error creating signature: %v", err)
 		}

--- a/vendor/github.com/containers/image/directory/directory_dest.go
+++ b/vendor/github.com/containers/image/directory/directory_dest.go
@@ -1,12 +1,12 @@
 package directory
 
 import (
-	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
 
 	"github.com/containers/image/types"
+	"github.com/docker/docker/reference"
 )
 
 type dirImageDestination struct {
@@ -18,8 +18,8 @@ func NewImageDestination(dir string) types.ImageDestination {
 	return &dirImageDestination{dir}
 }
 
-func (d *dirImageDestination) CanonicalDockerReference() (string, error) {
-	return "", fmt.Errorf("Can not determine canonical Docker reference for a local directory")
+func (d *dirImageDestination) CanonicalDockerReference() reference.Named {
+	return nil
 }
 
 func (d *dirImageDestination) SupportedManifestMIMETypes() []string {

--- a/vendor/github.com/containers/image/directory/directory_src.go
+++ b/vendor/github.com/containers/image/directory/directory_src.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/containers/image/types"
+	"github.com/docker/docker/reference"
 )
 
 type dirImageSource struct {
@@ -18,11 +19,12 @@ func NewImageSource(dir string) types.ImageSource {
 	return &dirImageSource{dir}
 }
 
-// IntendedDockerReference returns the full, unambiguous, Docker reference for this image, _as specified by the user_
-// (not as the image itself, or its underlying storage, claims).  This can be used e.g. to determine which public keys are trusted for this image.
-// May be "" if unknown.
-func (s *dirImageSource) IntendedDockerReference() string {
-	return ""
+// IntendedDockerReference returns the Docker reference for this image, _as specified by the user_
+// (not as the image itself, or its underlying storage, claims).  Should be fully expanded, i.e. !reference.IsNameOnly.
+// This can be used e.g. to determine which public keys are trusted for this image.
+// May be nil if unknown.
+func (s *dirImageSource) IntendedDockerReference() reference.Named {
+	return nil
 }
 
 // it's up to the caller to determine the MIME type of the returned manifest's bytes

--- a/vendor/github.com/containers/image/docker/docker_image_dest.go
+++ b/vendor/github.com/containers/image/docker/docker_image_dest.go
@@ -15,13 +15,12 @@ import (
 
 type dockerImageDestination struct {
 	ref reference.Named
-	tag string
 	c   *dockerClient
 }
 
 // NewImageDestination creates a new ImageDestination for the specified image and connection specification.
 func NewImageDestination(img, certPath string, tlsVerify bool) (types.ImageDestination, error) {
-	ref, tag, err := parseImageName(img)
+	ref, err := parseImageName(img)
 	if err != nil {
 		return nil, err
 	}
@@ -31,7 +30,6 @@ func NewImageDestination(img, certPath string, tlsVerify bool) (types.ImageDesti
 	}
 	return &dockerImageDestination{
 		ref: ref,
-		tag: tag,
 		c:   c,
 	}, nil
 }
@@ -45,8 +43,8 @@ func (d *dockerImageDestination) SupportedManifestMIMETypes() []string {
 	}
 }
 
-func (d *dockerImageDestination) CanonicalDockerReference() (string, error) {
-	return fmt.Sprintf("%s:%s", d.ref.Name(), d.tag), nil
+func (d *dockerImageDestination) CanonicalDockerReference() reference.Named {
+	return d.ref
 }
 
 func (d *dockerImageDestination) PutManifest(m []byte) error {

--- a/vendor/github.com/containers/image/docker/docker_utils.go
+++ b/vendor/github.com/containers/image/docker/docker_utils.go
@@ -1,20 +1,32 @@
 package docker
 
-import "github.com/docker/docker/reference"
+import (
+	"fmt"
 
-// parseImageName converts a string into a reference and tag value.
-func parseImageName(img string) (reference.Named, string, error) {
+	"github.com/docker/docker/reference"
+)
+
+// parseImageName converts a string into a reference.
+// It is guaranteed that reference.IsNameOnly is false for the returned value.
+func parseImageName(img string) (reference.Named, error) {
 	ref, err := reference.ParseNamed(img)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 	ref = reference.WithDefaultTag(ref)
-	var tag string
-	switch x := ref.(type) {
-	case reference.Canonical:
-		tag = x.Digest().String()
-	case reference.NamedTagged:
-		tag = x.Tag()
+	if reference.IsNameOnly(ref) { // Sanity check that we are fulfulling our contract
+		return nil, fmt.Errorf("Internal inconsistency: reference.IsNameOnly for reference %s (parsed from %s)", ref.String(), img)
 	}
-	return ref, tag, nil
+	return ref, nil
+}
+
+// tagOrDigest returns a tag or digest from a reference for which !reference.IsNameOnly.
+func tagOrDigest(ref reference.Named) (string, error) {
+	if ref, ok := ref.(reference.Canonical); ok {
+		return ref.Digest().String(), nil
+	}
+	if ref, ok := ref.(reference.NamedTagged); ok {
+		return ref.Tag(), nil
+	}
+	return "", fmt.Errorf("Internal inconsistency: Reference %s unexpectedly has neither a digest nor a tag", ref.String())
 }

--- a/vendor/github.com/containers/image/image/image.go
+++ b/vendor/github.com/containers/image/image/image.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
+	"github.com/docker/docker/reference"
 )
 
 var (
@@ -50,10 +51,11 @@ func FromSource(src types.ImageSource, requestedManifestMIMETypes []string) type
 	return &genericImage{src: src, requestedManifestMIMETypes: requestedManifestMIMETypes}
 }
 
-// IntendedDockerReference returns the full, unambiguous, Docker reference for this image, _as specified by the user_
-// (not as the image itself, or its underlying storage, claims).  This can be used e.g. to determine which public keys are trusted for this image.
-// May be "" if unknown.
-func (i *genericImage) IntendedDockerReference() string {
+// IntendedDockerReference returns the Docker reference for this image, _as specified by the user_
+// (not as the image itself, or its underlying storage, claims).  Should be fully expanded, i.e. !reference.IsNameOnly.
+// This can be used e.g. to determine which public keys are trusted for this image.
+// May be nil if unknown.
+func (i *genericImage) IntendedDockerReference() reference.Named {
 	return i.src.IntendedDockerReference()
 }
 

--- a/vendor/github.com/containers/image/oci/oci_dest.go
+++ b/vendor/github.com/containers/image/oci/oci_dest.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
+	"github.com/docker/docker/reference"
 )
 
 type ociManifest struct {
@@ -53,8 +54,8 @@ func NewImageDestination(dest string) (types.ImageDestination, error) {
 	}, nil
 }
 
-func (d *ociImageDestination) CanonicalDockerReference() (string, error) {
-	return "", fmt.Errorf("Can not determine canonical Docker reference for an OCI image")
+func (d *ociImageDestination) CanonicalDockerReference() reference.Named {
+	return nil
 }
 
 func createManifest(m []byte) ([]byte, string, error) {

--- a/vendor/github.com/containers/image/signature/policy_eval.go
+++ b/vendor/github.com/containers/image/signature/policy_eval.go
@@ -10,9 +10,8 @@ import (
 	"strings"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/docker/docker/reference"
 	"github.com/containers/image/types"
-	distreference "github.com/docker/distribution/reference"
+	"github.com/docker/docker/reference"
 )
 
 // PolicyRequirementError is an explanatory text for rejecting a signature or an image.
@@ -71,7 +70,8 @@ type PolicyRequirement interface {
 // The type is public, but its implementation is private.
 type PolicyReferenceMatch interface {
 	// matchesDockerReference decides whether a specific image identity is accepted for an image
-	// (or, usually, for the image's IntendedDockerReference()),
+	// (or, usually, for the image's IntendedDockerReference()).  Note that
+	// image.IntendedDockerReference() may be nil.
 	matchesDockerReference(image types.Image, signatureDockerReference string) bool
 }
 
@@ -132,14 +132,15 @@ func (pc *PolicyContext) Destroy() error {
 // FIXME? This feels like it should be provided by skopeo/reference.
 func fullyExpandedDockerReference(ref reference.Named) (string, error) {
 	res := ref.FullName()
-	tagged, isTagged := ref.(distreference.Tagged)
-	digested, isDigested := ref.(distreference.Digested)
+	tagged, isTagged := ref.(reference.NamedTagged)
+	digested, isDigested := ref.(reference.Canonical)
 	// A github.com/distribution/reference value can have a tag and a digest at the same time!
-	// skopeo/reference does not handle that, so fail.
-	// FIXME? Should we support that?
+	// github.com/docker/reference does not handle that, so fail.
+	// (Even if it were supported, the semantics of policy namespaces are unclear - should we drop
+	// the tag or the digest first?)
 	switch {
 	case isTagged && isDigested:
-		// Coverage: This should currently not happen, the way skopeo/reference sets up types,
+		// Coverage: This should currently not happen, the way docker/reference sets up types,
 		// isTagged and isDigested is mutually exclusive.
 		return "", fmt.Errorf("Names with both a tag and digest are not currently supported")
 	case isTagged:
@@ -154,15 +155,12 @@ func fullyExpandedDockerReference(ref reference.Named) (string, error) {
 
 // requirementsForImage selects the appropriate requirements for image.
 func (pc *PolicyContext) requirementsForImage(image types.Image) (PolicyRequirements, error) {
-	imageIdentity := image.IntendedDockerReference()
-	// We don't technically need to parse it first in order to match the full name:tag,
-	// but do so anyway to ensure that the intended identity really does follow that
-	// format, or at least that it is not demonstrably wrong.
-	ref, err := reference.ParseNamed(imageIdentity)
-	if err != nil {
-		return nil, err
+	ref := image.IntendedDockerReference()
+	if ref == nil {
+		// FIXME: Tell the user which image this is.
+		return nil, fmt.Errorf("Can not determine policy for an image with no known Docker reference identity")
 	}
-	ref = reference.WithDefaultTag(ref)
+	ref = reference.WithDefaultTag(ref) // This should not be needed, but if we did receive a name-only reference, this is a reasonable thing to do.
 
 	// Look for a full match.
 	fullyExpanded, err := fullyExpandedDockerReference(ref)

--- a/vendor/github.com/docker/libtrust/README.md
+++ b/vendor/github.com/docker/libtrust/README.md
@@ -1,5 +1,9 @@
 # libtrust
 
+> **WARNING** this library is no longer actively developed, and will be integrated
+> in the [docker/distribution][https://www.github.com/docker/distribution]
+> repository in future.
+
 Libtrust is library for managing authentication and authorization using public key cryptography.
 
 Authentication is handled using the identity attached to the public key.


### PR DESCRIPTION
This pulls in mtrmac/image:docker-references and updates for the API change, to demonstrate things working.

Do not merge as is, I will re-vendor from the master branch after merging the other PR.