### PR TITLE
fix upload to Docker Hub

### DIFF
--- a/vendor/github.com/containers/image/docker/docker_image_dest.go
+++ b/vendor/github.com/containers/image/docker/docker_image_dest.go
@@ -82,7 +82,7 @@ func (d *dockerImageDestination) PutBlob(digest string, stream io.Reader) error 
 	if err != nil {
 		return err
 	}
-	defer res.Body.Close()
+	res.Body.Close()
 	if res.StatusCode == http.StatusOK && res.Header.Get("Docker-Content-Digest") == digest {
 		logrus.Debugf("... already exists, not uploading")
 		return nil
@@ -96,7 +96,7 @@ func (d *dockerImageDestination) PutBlob(digest string, stream io.Reader) error 
 	if err != nil {
 		return err
 	}
-	defer res.Body.Close()
+	res.Body.Close()
 	if res.StatusCode != http.StatusAccepted {
 		logrus.Debugf("Error initiating layer upload, response %#v", *res)
 		return fmt.Errorf("Error initiating layer upload to %s, status %d", uploadURL, res.StatusCode)
@@ -115,7 +115,7 @@ func (d *dockerImageDestination) PutBlob(digest string, stream io.Reader) error 
 	if err != nil {
 		return err
 	}
-	defer res.Body.Close()
+	res.Body.Close()
 	if res.StatusCode != http.StatusCreated {
 		logrus.Debugf("Error uploading layer, response %#v", *res)
 		return fmt.Errorf("Error uploading layer to %s, status %d", uploadLocation, res.StatusCode)


### PR DESCRIPTION
@mtrmac PTAL this is fixing:
```sh
$ skopeo copy docker://runcom/test1 docker://runcom/test2
DEBU[0000] Ping https://registry-1.docker.io/v2/ err <nil> 
DEBU[0000] Ping https://registry-1.docker.io/v2/ status 401 
DEBU[0001] GET https://registry-1.docker.io/v2/runcom/alpinetest/manifests/latest 
DEBU[0001] Downloading runcom/alpinetest/blobs/sha256:e110a4a1794126ef308a49f2d65785af2f25538f06700721aad8283b81fdfa58 
DEBU[0002] GET https://registry-1.docker.io/v2/runcom/alpinetest/blobs/sha256:e110a4a1794126ef308a49f2d65785af2f25538f06700721aad8283b81fdfa58 
DEBU[0003] Checking runcom/busybox/blobs/sha256:e110a4a1794126ef308a49f2d65785af2f25538f06700721aad8283b81fdfa58 
DEBU[0004] Ping https://registry-1.docker.io/v2/ err <nil> 
DEBU[0004] Ping https://registry-1.docker.io/v2/ status 401 
DEBU[0004] HEAD https://registry-1.docker.io/v2/runcom/busybox/blobs/sha256:e110a4a1794126ef308a49f2d65785af2f25538f06700721aad8283b81fdfa58 
DEBU[0005] ... failed, status 200                       
DEBU[0005] Uploading runcom/busybox/blobs/uploads/      
DEBU[0006] POST https://registry-1.docker.io/v2/runcom/busybox/blobs/uploads/ 
DEBU[0006] Error initiating layer upload, response http.Response{Status:"401 Unauthorized", StatusCode:401, Proto:"HTTP/1.1", ProtoMajor:1, ProtoMinor:1, Header:http.Header{"Www-Authenticate":[]string{"Bearer realm=\"https://auth.docker.io/token\",service=\"registry.docker.io\",scope=\"repository:runcom/busybox:pull,push\",error=\"insufficient_scope\""}, "Date":[]string{"Thu, 21 Jul 2016 10:49:35 GMT"}, "Content-Length":[]string{"208"}, "Strict-Transport-Security":[]string{"max-age=31536000"}, "Content-Type":[]string{"application/json; charset=utf-8"}, "Docker-Distribution-Api-Version":[]string{"registry/2.0"}}, Body:(*http.cancelTimerBody)(0xc820136a20), ContentLength:208, TransferEncoding:[]string(nil), Close:false, Trailer:http.Header(nil), Request:(*http.Request)(0xc8203d07e0), TLS:(*tls.ConnectionState)(0xc8203d2fd0)} 
FATA[0006] Error writing blob: Error initiating layer upload to runcom/busybox/blobs/uploads/, status 401
```
and after fixing the error above:
```sh
$ skopeo copy docker://runcom/test1 docker://runcom/test2
DEBU[0000] Ping https://registry-1.docker.io/v2/ err <nil> 
DEBU[0000] Ping https://registry-1.docker.io/v2/ status 401 
DEBU[0001] GET https://registry-1.docker.io/v2/runcom/alpinetest/manifests/latest 
DEBU[0001] Downloading runcom/alpinetest/blobs/sha256:e110a4a1794126ef308a49f2d65785af2f25538f06700721aad8283b81fdfa58 
DEBU[0002] GET https://registry-1.docker.io/v2/runcom/alpinetest/blobs/sha256:e110a4a1794126ef308a49f2d65785af2f25538f06700721aad8283b81fdfa58 
DEBU[0003] Checking runcom/busybox/blobs/sha256:e110a4a1794126ef308a49f2d65785af2f25538f06700721aad8283b81fdfa58 
DEBU[0004] Ping https://registry-1.docker.io/v2/ err <nil> 
DEBU[0004] Ping https://registry-1.docker.io/v2/ status 401 
DEBU[0004] HEAD https://registry-1.docker.io/v2/runcom/busybox/blobs/sha256:e110a4a1794126ef308a49f2d65785af2f25538f06700721aad8283b81fdfa58 
DEBU[0005] ... failed, status 200                       
DEBU[0005] Uploading runcom/busybox/blobs/uploads/      
DEBU[0006] POST https://registry-1.docker.io/v2/runcom/busybox/blobs/uploads/ 
DEBU[0010] PUT https://registry-1.docker.io/v2/runcom/busybox/blobs/uploads/4ff6c6af-a686-47bb-8d88-58bbac910e78?_state=gEEtsS_VbGmF7KFkc6B_hMfc7WlqD5wpwWA3TvBu2VZ7Ik5hbWUiOiJydW5jb20vYnVzeWJveCIsIlVVSUQiOiI0ZmY2YzZhZi1hNjg2LTQ3YmItOGQ4OC01OGJiYWM5MTBlNzgiLCJPZmZzZXQiOjAsIlN0YXJ0ZWRBdCI6IjIwMTYtMDctMjFUMTA6NTI6MDIuOTk5MDU4NDEzWiJ9&digest=sha256%3Ae110a4a1794126ef308a49f2d65785af2f25538f06700721aad8283b81fdfa58 
DEBU[0029] Error uploading layer, response http.Response{Status:"400 Bad Request", StatusCode:400, Proto:"HTTP/1.1", ProtoMajor:1, ProtoMinor:1, Header:http.Header{"Content-Type":[]string{"application/json; charset=utf-8"}, "Docker-Distribution-Api-Version":[]string{"registry/2.0"}, "Date":[]string{"Thu, 21 Jul 2016 10:52:25 GMT"}, "Content-Length":[]string{"204"}, "Strict-Transport-Security":[]string{"max-age=31536000"}}, Body:(*http.cancelTimerBody)(0xc8204aaac0), ContentLength:204, TransferEncoding:[]string(nil), Close:false, Trailer:http.Header(nil), Request:(*http.Request)(0xc82016a000), TLS:(*tls.ConnectionState)(0xc82022c370)} 
FATA[0029] Error writing blob: Error uploading layer to https://registry-1.docker.io/v2/runcom/busybox/blobs/uploads/4ff6c6af-a686-47bb-8d88-58bbac910e78?_state=gEEtsS_VbGmF7KFkc6B_hMfc7WlqD5wpwWA3TvBu2VZ7Ik5hbWUiOiJydW5jb20vYnVzeWJveCIsIlVVSUQiOiI0ZmY2YzZhZi1hNjg2LTQ3YmItOGQ4OC01OGJiYWM5MTBlNzgiLCJPZmZzZXQiOjAsIlN0YXJ0ZWRBdCI6IjIwMTYtMDctMjFUMTA6NTI6MDIuOTk5MDU4NDEzWiJ9&digest=sha256%3Ae110a4a1794126ef308a49f2d65785af2f25538f06700721aad8283b81fdfa58, status 400
```

There were basically 2 issues:

1. the `scope` field from the Bearer token was being read wrongly in case it was returning more action (e.g. `pull, push`)
2. the request body is being read by `client.Do` inside `setupRequestAuth`

The former came up as a consequence of the first bug.

Signed-off-by: Antonio Murdaca <runcom@redhat.com>