### PR TITLE
Update OpenShift

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,9 +43,7 @@ RUN set -x \
 RUN set -x \
 	&& yum install -y which git tar wget hostname util-linux bsdtar socat ethtool device-mapper iptables tree findutils nmap-ncat e2fsprogs xfsprogs lsof docker iproute \
 	&& export GOPATH=$(mktemp -d) \
-	# && git clone git://github.com/openshift/origin "$GOPATH/src/github.com/openshift/origin" \
-	# && git clone -b image-signatures-rest git://github.com/miminar/origin "$GOPATH/src/github.com/openshift/origin" \
-	&& git clone -b image-signatures-rest-backup git://github.com/mtrmac/origin "$GOPATH/src/github.com/openshift/origin" \
+	&& git clone -b v1.3.0-alpha.3 git://github.com/openshift/origin "$GOPATH/src/github.com/openshift/origin" \
 	&& (cd "$GOPATH/src/github.com/openshift/origin" && make clean build && make all WHAT=cmd/dockerregistry) \
 	&& cp -a "$GOPATH/src/github.com/openshift/origin/_output/local/bin/linux"/*/* /usr/local/bin \
 	&& cp "$GOPATH/src/github.com/openshift/origin/images/dockerregistry/config.yml" /atomic-registry-config.yml \


### PR DESCRIPTION
With #139 , we have frozen OpenShift at an old version to keep our signature storage client working.

This updates OpenShift to the final version of https://github.com/openshift/origin/pull/9181 .

(Conceptually, this should be committed simultaneously with https://github.com/projectatomic/skopeo/pull/93 . But we haven’t merged integration tests for signatures yet, so this inconsistency does not show up as a test failure yet.  So, filing this as a separate PR for simpler review.)