### PR TITLE
WIP: bash completion

### DIFF
--- a/cmd/skopeo/main.go
+++ b/cmd/skopeo/main.go
@@ -16,6 +16,7 @@ var gitCommit = ""
 // createApp returns a cli.App to be run or tested.
 func createApp() *cli.App {
 	app := cli.NewApp()
+	app.EnableBashCompletion = true
 	app.Name = "skopeo"
 	if gitCommit != "" {
 		app.Version = fmt.Sprintf("%s commit: %s", version.Version, gitCommit)


### PR DESCRIPTION
This only adds `--generate-bash-completion` for the subcommand names; needs integration with the bash completion infrastructure (available in `github.com/urfave/cli`).

The API may also support completion for non-subcommands (options, arguments), but AFAICS provides little to no infrastructure for it, so it would be noticeably more work.