### PR TITLE
Verify signatures on pull

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ export GO15VENDOREXPERIMENT=1
 PREFIX ?= ${DESTDIR}/usr
 INSTALLDIR=${PREFIX}/bin
 MANINSTALLDIR=${PREFIX}/share/man
+CONTAINERSSYSCONFIGDIR=${DESTDIR}/etc/containers
 BASHINSTALLDIR=${PREFIX}/share/bash-completion/completions
 GO_MD2MAN ?= /usr/bin/go-md2man
 
@@ -60,14 +61,13 @@ clean:
 	rm -f skopeo docs/*.1
 
 install: install-binary install-docs install-completions
+	install -D -m 644 default-policy.json ${CONTAINERSSYSCONFIGDIR}/policy.json
 
 install-binary: ./skopeo
-	install -d -m 0755 ${INSTALLDIR}
-	install -m 755 skopeo ${INSTALLDIR}
+	install -D -m 755 skopeo ${INSTALLDIR}/skopeo
 
 install-docs: docs/skopeo.1
-	install -d -m 0755 ${MANINSTALLDIR}/man1
-	install -m 644 docs/skopeo.1 ${MANINSTALLDIR}/man1/
+	install -D -m 644 docs/skopeo.1 ${MANINSTALLDIR}/man1/skopeo.1
 
 install-completions:
 	install -m 644 -T hack/make/bash_autocomplete ${BASHINSTALLDIR}/skopeo

--- a/default-policy.json
+++ b/default-policy.json
@@ -1,0 +1,7 @@
+{
+    "default": [
+        {
+            "type": "insecureAcceptAnything"
+        }
+    ]
+}

--- a/docs/skopeo.1.md
+++ b/docs/skopeo.1.md
@@ -59,6 +59,8 @@ Most commands refer to container images, using a _transport_`:`_details_ format.
 
 Copy an image (manifest, filesystem layers, signatures) from one location to another.
 
+Uses the system's signature verification policy to validate images, refuses to copy images rejected by the policy.
+
   _source-image_ use the "image name" format described above
 
   _destination-image_ use the "image name" format described above

--- a/docs/skopeo.1.md
+++ b/docs/skopeo.1.md
@@ -43,6 +43,9 @@ Most commands refer to container images, using a _transport_`:`_details_ format.
 
   **--cert-path** _path_ Use certificates at _path_ (cert.pem, key.pem) to connect to the registry
 
+  **--policy** _path-to-policy_ Path to a policy.json file to use for verifying signatures and
+  deciding whether an image is accepted, instead of the default policy.
+
   **--tls-verify** _bool-value_ Verify certificates
 
   **--help**|**-h** Show help
@@ -127,6 +130,11 @@ Verify a signature using local files, digest will be printed on success.
 
 ## skopeo help
 show help for `skopeo`
+
+# FILES
+  **/etc/containers/policy.json**
+  Default signature verification policy file, if **--policy** is not specified.
+  The policy format is documented in https://github.com/containers/image/blob/master/docs/policy.json.md .
 
 # EXAMPLES
 

--- a/hack/make/test-integration
+++ b/hack/make/test-integration
@@ -9,7 +9,7 @@ bundle_test_integration() {
 # subshell so that we can export PATH without breaking other things
 (
 	make binary-local
-	make install-binary
+	make install
 	export GO15VENDOREXPERIMENT=1
 	bundle_test_integration
 ) 2>&1

--- a/vendor/github.com/containers/image/docker/docker_transport.go
+++ b/vendor/github.com/containers/image/docker/docker_transport.go
@@ -9,7 +9,7 @@ import (
 	"github.com/docker/docker/reference"
 )
 
-// Transport is an ImageTransport for Docker references.
+// Transport is an ImageTransport for Docker registry-hosted images.
 var Transport = dockerTransport{}
 
 type dockerTransport struct{}

--- a/vendor/github.com/containers/image/oci/oci_transport.go
+++ b/vendor/github.com/containers/image/oci/oci_transport.go
@@ -12,7 +12,7 @@ import (
 	"github.com/docker/docker/reference"
 )
 
-// Transport is an ImageTransport for Docker references.
+// Transport is an ImageTransport for OCI directories.
 var Transport = ociTransport{}
 
 type ociTransport struct{}

--- a/vendor/github.com/containers/image/openshift/openshift_transport.go
+++ b/vendor/github.com/containers/image/openshift/openshift_transport.go
@@ -12,7 +12,7 @@ import (
 	"github.com/docker/docker/reference"
 )
 
-// Transport is an ImageTransport for directory paths.
+// Transport is an ImageTransport for OpenShift registry-hosted images.
 var Transport = openshiftTransport{}
 
 type openshiftTransport struct{}

--- a/vendor/github.com/containers/image/types/types.go
+++ b/vendor/github.com/containers/image/types/types.go
@@ -147,3 +147,12 @@ type ImageInspectInfo struct {
 	Os            string
 	Layers        []string
 }
+
+// SystemContext allows parametrizing access to implicitly-accessed resources,
+// like configuration files in /etc and users' login state in their home directory.
+// Various components can share the same field only if their semantics is exactly
+// the same; if in doubt, add a new field.
+// It is always OK to pass nil instead of a SystemContext.
+type SystemContext struct {
+	SignaturePolicyPath string // If not "", overrides the system's default path for signature.Policy configuration.
+}

--- a/vendor/github.com/davecgh/go-spew/LICENSE
+++ b/vendor/github.com/davecgh/go-spew/LICENSE
@@ -1,3 +1,5 @@
+ISC License
+
 Copyright (c) 2012-2013 Dave Collins <dave@davec.name>
 
 Permission to use, copy, modify, and distribute this software for any


### PR DESCRIPTION
Adds `/etc/atomic/policy.json`, and a command-line option to override (`skopeo --policy some_path copy …`), and enforces this policy in `skopeo copy`.

`make install` now installs `default-policy.json` to `/etc/atomic/policy.json`; the policy is set to `insecureAcceptAnything` for all images by default. (This may not be desirable long-term, but it is a reasonable transition strategy for now I think. The policy always uses the most specific matching scope, so it is easy to e.g. pin a key and require signatures for a specific repository namespace.)

Note that with merging this, `./skopeo` will abort if the policy in `/etc/atomic` does not exist. This should not affect real deployments, but may be noticeable with local checkouts. A bit regrettable, but we do need to fail closed if a policy can’t be read.  (Use `./skopeo --policy default-policy.json …` in a checkout.)

This depends on, and vendors in, unmerged https://github.com/containers/image/pull/49 and https://github.com/containers/image/pull/50 , I will revendor as necessary.

@lsm5 , note that adding the config file will affect packaging.

@rhatdan , any comments on the path `/etc/atomic/policy.json`?