### PR TITLE
Copy signing integration tests

### DIFF
--- a/integration/fixtures/policy.json
+++ b/integration/fixtures/policy.json
@@ -1,0 +1,84 @@
+{
+    "default": [
+        {
+            "type": "reject"
+        }
+    ],
+    "transports": {
+        "docker": {
+            "docker.io/openshift": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ]
+        },
+        "dir": {
+            "/@dirpath@": [
+                {
+                    "type": "signedBy",
+                    "keyType": "GPGKeys",
+                    "keyPath": "@keydir@/official-pubkey.gpg",
+                    "signedIdentity": {
+                        "type": "exactRepository",
+                        "dockerRepository": "localhost:8443/myns/official"
+                    }
+                }
+            ],
+            "": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ]
+        },
+        "atomic": {
+            "localhost:8443/myns/personal": [
+                {
+                    "type": "signedBy",
+                    "keyType": "GPGKeys",
+                    "keyPath": "@keydir@/personal-pubkey.gpg"
+                }
+            ],
+            "localhost:8443/myns/official": [
+                {
+                    "type": "signedBy",
+                    "keyType": "GPGKeys",
+                    "keyPath": "@keydir@/official-pubkey.gpg"
+                }
+            ],
+            "localhost:8443/myns/naming:test1": [
+                {
+                    "type": "signedBy",
+                    "keyType": "GPGKeys",
+                    "keyPath": "@keydir@/official-pubkey.gpg"
+                }
+            ],
+            "localhost:8443/myns/naming:naming": [
+                {
+                    "type": "signedBy",
+                    "keyType": "GPGKeys",
+                    "keyPath": "@keydir@/official-pubkey.gpg",
+                    "signedIdentity": {
+                        "type": "exactRepository",
+                        "dockerRepository": "localhost:8443/myns/official"
+                    }
+                }
+            ],
+            "localhost:8443/myns/cosigned:cosigned": [
+                {
+                    "type": "signedBy",
+                    "keyType": "GPGKeys",
+                    "keyPath": "@keydir@/official-pubkey.gpg",
+                    "signedIdentity": {
+                        "type": "exactRepository",
+                        "dockerRepository": "localhost:8443/myns/official"
+                    }
+                },
+                {
+                    "type": "signedBy",
+                    "keyType": "GPGKeys",
+                    "keyPath": "@keydir@/personal-pubkey.gpg"
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
This includes https://github.com/projectatomic/skopeo/pull/146 and https://github.com/projectatomic/skopeo/pull/157 (I will rebase after those are merged), and adds integration tests for the signature and policy handling by `skopeo copy`.