### PR TITLE
Improve manifest digest handling

### DIFF
--- a/cmd/skopeo/fixtures/v2s1-invalid-signatures.manifest.json
+++ b/cmd/skopeo/fixtures/v2s1-invalid-signatures.manifest.json
@@ -1,0 +1,11 @@
+{
+   "schemaVersion": 1,
+   "name": "mitr/buxybox",
+   "tag": "latest",
+   "architecture": "amd64",
+   "fsLayers": [
+   ],
+   "history": [
+   ],
+   "signatures": 1
+}

--- a/cmd/skopeo/inspect.go
+++ b/cmd/skopeo/inspect.go
@@ -44,7 +44,10 @@ var inspectCmd = cli.Command{
 			return err
 		}
 		if c.Bool("raw") {
-			fmt.Fprintln(c.App.Writer, string(rawManifest))
+			_, err := c.App.Writer.Write(rawManifest)
+			if err != nil {
+				return fmt.Errorf("Error writing manifest to standard output: %v", err)
+			}
 			return nil
 		}
 		imgInspect, err := img.Inspect()

--- a/cmd/skopeo/main.go
+++ b/cmd/skopeo/main.go
@@ -61,6 +61,7 @@ func createApp() *cli.App {
 		inspectCmd,
 		layersCmd,
 		deleteCmd,
+		manifestDigestCmd,
 		standaloneSignCmd,
 		standaloneVerifyCmd,
 	}

--- a/cmd/skopeo/manifest.go
+++ b/cmd/skopeo/manifest.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/containers/image/manifest"
+	"github.com/urfave/cli"
+)
+
+func manifestDigest(context *cli.Context) error {
+	if len(context.Args()) != 1 {
+		return errors.New("Usage: skopeo manifest-digest manifest")
+	}
+	manifestPath := context.Args()[0]
+
+	man, err := ioutil.ReadFile(manifestPath)
+	if err != nil {
+		return fmt.Errorf("Error reading manifest from %s: %v", manifestPath, err)
+	}
+	digest, err := manifest.Digest(man)
+	if err != nil {
+		return fmt.Errorf("Error computing digest: %v", err)
+	}
+	fmt.Fprintf(context.App.Writer, "%s\n", digest)
+	return nil
+}
+
+var manifestDigestCmd = cli.Command{
+	Name:      "manifest-digest",
+	Usage:     "Compute a manifest digest of a file",
+	ArgsUsage: "MANIFEST",
+	Action:    manifestDigest,
+}

--- a/cmd/skopeo/manifest_test.go
+++ b/cmd/skopeo/manifest_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestManifestDigest(t *testing.T) {
+	// Invalid command-line arguments
+	for _, args := range [][]string{
+		{},
+		{"a1", "a2"},
+	} {
+		out, err := runSkopeo(append([]string{"manifest-digest"}, args...)...)
+		assertTestFailed(t, out, err, "Usage")
+	}
+
+	// Error reading manifest
+	out, err := runSkopeo("manifest-digest", "/this/doesnt/exist")
+	assertTestFailed(t, out, err, "/this/doesnt/exist")
+
+	// Error computing manifest
+	out, err = runSkopeo("manifest-digest", "fixtures/v2s1-invalid-signatures.manifest.json")
+	assertTestFailed(t, out, err, "computing digest")
+
+	// Success
+	out, err = runSkopeo("manifest-digest", "fixtures/image.manifest.json")
+	assert.NoError(t, err)
+	assert.Equal(t, fixturesTestImageManifestDigest+"\n", out)
+}

--- a/docs/skopeo.1.md
+++ b/docs/skopeo.1.md
@@ -91,6 +91,11 @@ Get image layers of _image-name_
 
   _image-name_ name of the image to retrieve layers
 
+## skopeo manifest-digest
+**skopeo manifest-digest** _manifest-file_
+
+Compute a manifest digest of _manifest-file_ and write it to standard output. 
+
 ## skopeo standalone-sign
 **skopeo standalone-sign** _manifest docker-reference key-fingerprint_ **--output**|**-o** _signature_
 
@@ -183,6 +188,11 @@ $ ls layers-500650331/
   8ddc19f16526912237dd8af81971d5e4dd0587907234be2b83e249518d5b673f.tar
   manifest.json
   a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4.tar
+```
+## skopeo manifest-digest
+```sh
+$ skopeo manifest-digest manifest.json
+sha256:a59906e33509d14c036c8678d687bd4eec81ed7c4b8ce907b888c607f6a1e0e6
 ```
 ## skopeo standalone-sign
 ```sh


### PR DESCRIPTION
 - Modify `skopeo inspect --raw` to output an _unmodified_ manifest.
 - Provide `skopeo manifest-digest $manifest_file` to compute a manifest digest, including the v2s1 signature stripping.

Both will be called by `atomic`.