### PR TITLE
Implement a lookaside storage for signatures of images in Docker registries

### DIFF
--- a/cmd/skopeo/main.go
+++ b/cmd/skopeo/main.go
@@ -56,6 +56,11 @@ func createApp() *cli.App {
 			Value: "",
 			Usage: "Path to a trust policy file",
 		},
+		cli.StringFlag{
+			Name:  "registries.d",
+			Value: "",
+			Usage: "use registry configuration files in `DIR` (e.g. for docker signature storage)",
+		},
 	}
 	app.Before = func(c *cli.Context) error {
 		if c.GlobalBool("debug") {

--- a/cmd/skopeo/utils.go
+++ b/cmd/skopeo/utils.go
@@ -8,10 +8,10 @@ import (
 
 // contextFromGlobalOptions returns a types.SystemContext depending on c.
 func contextFromGlobalOptions(c *cli.Context) *types.SystemContext {
-	certPath := c.GlobalString("cert-path")
 	tlsVerify := c.GlobalBool("tls-verify") // FIXME!! defaults to false
 	return &types.SystemContext{
-		DockerCertPath:              certPath,
+		RegistriesDirPath:           c.GlobalString("registries.d"),
+		DockerCertPath:              c.GlobalString("cert-path"),
 		DockerInsecureSkipTLSVerify: !tlsVerify,
 	}
 }

--- a/docs/skopeo.1.md
+++ b/docs/skopeo.1.md
@@ -45,6 +45,8 @@ Most commands refer to container images, using a _transport_`:`_details_ format.
 
   **--policy** _path-to-policy_ Path to a policy.json file to use for verifying signatures and deciding whether an image is trusted, overriding the default trust policy file.
 
+  **--registries.d** _dir_ use registry configuration files in _dir_ (e.g. for docker signature storage), overriding the default path.
+
   **--tls-verify** _bool-value_ Verify certificates
 
   **--help**|**-h** Show help
@@ -64,7 +66,7 @@ Uses the system's trust policy to validate images, rejects images not trusted by
 
   _destination-image_ use the "image name" format described above
 
-  **--remove-signatures** do not copy signatures, if any, from _source-image_. Necessary when copying a signed image to a destination which does not support signatures. 
+  **--remove-signatures** do not copy signatures, if any, from _source-image_. Necessary when copying a signed image to a destination which does not support signatures.
 
   **--sign-by=**_key-id_ add a signature using that key ID for an image name corresponding to _destination-image_
 
@@ -100,7 +102,7 @@ Get image layers of _image-name_
 ## skopeo manifest-digest
 **skopeo manifest-digest** _manifest-file_
 
-Compute a manifest digest of _manifest-file_ and write it to standard output. 
+Compute a manifest digest of _manifest-file_ and write it to standard output.
 
 ## skopeo standalone-sign
 **skopeo standalone-sign** _manifest docker-reference key-fingerprint_ **--output**|**-o** _signature_
@@ -138,6 +140,10 @@ show help for `skopeo`
   **/etc/containers/policy.json**
   Default trust policy file, if **--policy** is not specified.
   The policy format is documented in https://github.com/containers/image/blob/master/docs/policy.json.md .
+
+  **/etc/containers/registries.d**
+  Default directory containing registry configuration, if **--registries.d** is not specified.
+  The contents of this directory are documented in https://github.com/containers/image/blob/master/docs/registries.d.md .
 
 # EXAMPLES
 

--- a/vendor/github.com/containers/image/docker/docker_client.go
+++ b/vendor/github.com/containers/image/docker/docker_client.go
@@ -42,17 +42,17 @@ type dockerClient struct {
 	wwwAuthenticate string // Cache of a value set by ping() if scheme is not empty
 	scheme          string // Cache of a value returned by a successful ping() if not empty
 	client          *http.Client
+	signatureBase   signatureStorageBase
 }
 
 // newDockerClient returns a new dockerClient instance for refHostname (a host a specified in the Docker image reference, not canonicalized to dockerRegistry)
-func newDockerClient(ctx *types.SystemContext, refHostname string) (*dockerClient, error) {
-	var registry string
-	if refHostname == dockerHostname {
+// “write” specifies whether the client will be used for "write" access (in particular passed to lookaside.go:toplevelFromSection)
+func newDockerClient(ctx *types.SystemContext, ref dockerReference, write bool) (*dockerClient, error) {
+	registry := ref.ref.Hostname()
+	if registry == dockerHostname {
 		registry = dockerRegistry
-	} else {
-		registry = refHostname
 	}
-	username, password, err := getAuth(refHostname)
+	username, password, err := getAuth(ref.ref.Hostname())
 	if err != nil {
 		return nil, err
 	}
@@ -78,11 +78,18 @@ func newDockerClient(ctx *types.SystemContext, refHostname string) (*dockerClien
 	if tr != nil {
 		client.Transport = tr
 	}
+
+	sigBase, err := configuredSignatureStorageBase(ctx, ref, write)
+	if err != nil {
+		return nil, err
+	}
+
 	return &dockerClient{
-		registry: registry,
-		username: username,
-		password: password,
-		client:   client,
+		registry:      registry,
+		username:      username,
+		password:      password,
+		client:        client,
+		signatureBase: sigBase,
 	}, nil
 }
 

--- a/vendor/github.com/containers/image/docker/lookaside.go
+++ b/vendor/github.com/containers/image/docker/lookaside.go
@@ -1,0 +1,198 @@
+package docker
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/ghodss/yaml"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/containers/image/types"
+)
+
+// systemRegistriesDirPath is the path to registries.d, used for locating lookaside Docker signature storage.
+// You can override this at build time with
+// -ldflags '-X github.com/containers/image/docker.systemRegistriesDirPath=$your_path'
+var systemRegistriesDirPath = builtinRegistriesDirPath
+
+// builtinRegistriesDirPath is the path to registries.d.
+// DO NOT change this, instead see systemRegistriesDirPath above.
+const builtinRegistriesDirPath = "/etc/containers/registries.d"
+
+// registryConfiguration is one of the files in registriesDirPath configuring lookaside locations, or the result of merging them all.
+// NOTE: Keep this in sync with docs/registries.d.md!
+type registryConfiguration struct {
+	DefaultDocker *registryNamespace `json:"default-docker"`
+	// The key is a namespace, using fully-expanded Docker reference format or parent namespaces (per dockerReference.PolicyConfiguration*),
+	Docker map[string]registryNamespace `json:"docker"`
+}
+
+// registryNamespace defines lookaside locations for a single namespace.
+type registryNamespace struct {
+	SigStore      string `json:"sigstore"`       // For reading, and if SigStoreWrite is not present, for writing.
+	SigStoreWrite string `json:"sigstore-write"` // For writing only.
+}
+
+// signatureStorageBase is an "opaque" type representing a lookaside Docker signature storage.
+// Users outside of this file should use configuredSignatureStorageBase and signatureStorageURL below.
+type signatureStorageBase *url.URL // The only documented value is nil, meaning storage is not supported.
+
+// configuredSignatureStorageBase reads configuration to find an appropriate signature storage URL for ref, for write access if “write”.
+func configuredSignatureStorageBase(ctx *types.SystemContext, ref dockerReference, write bool) (signatureStorageBase, error) {
+	// FIXME? Loading and parsing the config could be cached across calls.
+	dirPath := registriesDirPath(ctx)
+	logrus.Debugf(`Using registries.d directory %s for sigstore configuration`, dirPath)
+	config, err := loadAndMergeConfig(dirPath)
+	if err != nil {
+		return nil, err
+	}
+
+	topLevel := config.signatureTopLevel(ref, write)
+	if topLevel == "" {
+		return nil, nil
+	}
+
+	url, err := url.Parse(topLevel)
+	if err != nil {
+		return nil, fmt.Errorf("Invalid signature storage URL %s: %v", topLevel, err)
+	}
+	// FIXME? Restrict to explicitly supported schemes?
+	repo := ref.ref.FullName()    // Note that this is without a tag or digest.
+	if path.Clean(repo) != repo { // Coverage: This should not be reachable because /./ and /../ components are not valid in docker references
+		return nil, fmt.Errorf("Unexpected path elements in Docker reference %s for signature storage", ref.ref.String())
+	}
+	url.Path = url.Path + "/" + repo
+	return url, nil
+}
+
+// registriesDirPath returns a path to registries.d
+func registriesDirPath(ctx *types.SystemContext) string {
+	if ctx != nil {
+		if ctx.RegistriesDirPath != "" {
+			return ctx.RegistriesDirPath
+		}
+		if ctx.RootForImplicitAbsolutePaths != "" {
+			return filepath.Join(ctx.RootForImplicitAbsolutePaths, systemRegistriesDirPath)
+		}
+	}
+	return systemRegistriesDirPath
+}
+
+// loadAndMergeConfig loads configuration files in dirPath
+func loadAndMergeConfig(dirPath string) (*registryConfiguration, error) {
+	mergedConfig := registryConfiguration{Docker: map[string]registryNamespace{}}
+	dockerDefaultMergedFrom := ""
+	nsMergedFrom := map[string]string{}
+
+	dir, err := os.Open(dirPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &mergedConfig, nil
+		}
+		return nil, err
+	}
+	configNames, err := dir.Readdirnames(0)
+	if err != nil {
+		return nil, err
+	}
+	for _, configName := range configNames {
+		if !strings.HasSuffix(configName, ".yaml") {
+			continue
+		}
+		configPath := filepath.Join(dirPath, configName)
+		configBytes, err := ioutil.ReadFile(configPath)
+		if err != nil {
+			return nil, err
+		}
+
+		var config registryConfiguration
+		err = yaml.Unmarshal(configBytes, &config)
+		if err != nil {
+			return nil, fmt.Errorf("Error parsing %s: %v", configPath, err)
+		}
+
+		if config.DefaultDocker != nil {
+			if mergedConfig.DefaultDocker != nil {
+				return nil, fmt.Errorf(`Error parsing signature storage configuration: "default-docker" defined both in "%s" and "%s"`,
+					dockerDefaultMergedFrom, configPath)
+			}
+			mergedConfig.DefaultDocker = config.DefaultDocker
+			dockerDefaultMergedFrom = configPath
+		}
+
+		for nsName, nsConfig := range config.Docker { // includes config.Docker == nil
+			if _, ok := mergedConfig.Docker[nsName]; ok {
+				return nil, fmt.Errorf(`Error parsing signature storage configuration: "docker" namespace "%s" defined both in "%s" and "%s"`,
+					nsName, nsMergedFrom[nsName], configPath)
+			}
+			mergedConfig.Docker[nsName] = nsConfig
+			nsMergedFrom[nsName] = configPath
+		}
+	}
+
+	return &mergedConfig, nil
+}
+
+// config.signatureTopLevel returns an URL string configured in config for ref, for write access if “write”.
+// (the top level of the storage, namespaced by repo.FullName etc.), or "" if no signature storage should be used.
+func (config *registryConfiguration) signatureTopLevel(ref dockerReference, write bool) string {
+	if config.Docker != nil {
+		// Look for a full match.
+		identity := ref.PolicyConfigurationIdentity()
+		if ns, ok := config.Docker[identity]; ok {
+			logrus.Debugf(` Using "docker" namespace %s`, identity)
+			if url := ns.signatureTopLevel(write); url != "" {
+				return url
+			}
+		}
+
+		// Look for a match of the possible parent namespaces.
+		for _, name := range ref.PolicyConfigurationNamespaces() {
+			if ns, ok := config.Docker[name]; ok {
+				logrus.Debugf(` Using "docker" namespace %s`, name)
+				if url := ns.signatureTopLevel(write); url != "" {
+					return url
+				}
+			}
+		}
+	}
+	// Look for a default location
+	if config.DefaultDocker != nil {
+		logrus.Debugf(` Using "default-docker" configuration`)
+		if url := config.DefaultDocker.signatureTopLevel(write); url != "" {
+			return url
+		}
+	}
+	logrus.Debugf(" No signature storage configuration found for %s", ref.PolicyConfigurationIdentity())
+	return ""
+}
+
+// ns.signatureTopLevel returns an URL string configured in ns for ref, for write access if “write”.
+// or "" if nothing has been configured.
+func (ns registryNamespace) signatureTopLevel(write bool) string {
+	if write && ns.SigStoreWrite != "" {
+		logrus.Debugf(`  Using %s`, ns.SigStoreWrite)
+		return ns.SigStoreWrite
+	}
+	if ns.SigStore != "" {
+		logrus.Debugf(`  Using %s`, ns.SigStore)
+		return ns.SigStore
+	}
+	return ""
+}
+
+// signatureStorageURL returns an URL usable for acessing signature index in base with known manifestDigest, or nil if not applicable.
+// Returns nil iff base == nil.
+func signatureStorageURL(base signatureStorageBase, manifestDigest string, index int) *url.URL {
+	if base == nil {
+		return nil
+	}
+	url := *base
+	url.Path = fmt.Sprintf("%s@%s/signature-%d", url.Path, manifestDigest, index+1)
+	return &url
+}

--- a/vendor/github.com/containers/image/types/types.go
+++ b/vendor/github.com/containers/image/types/types.go
@@ -188,12 +188,16 @@ type SystemContext struct {
 	// If not "", prefixed to any absolute paths used by default by the library (e.g. in /etc/).
 	// Not used for any of the more specific path overrides available in this struct.
 	// Not used for any paths specified by users in config files (even if the location of the config file _was_ affected by it).
+	// NOTE: If this is set, environment-variable overrides of paths are ignored (to keep the semantics simple: to create an /etc replacement, just set RootForImplicitAbsolutePaths .
+	// and there is no need to worry about the environment.)
 	// NOTE: This does NOT affect paths starting by $HOME.
 	RootForImplicitAbsolutePaths string
 
 	// === Global configuration overrides ===
 	// If not "", overrides the system's default path for signature.Policy configuration.
 	SignaturePolicyPath string
+	// If not "", overrides the system's default path for registries.d (Docker signature storage configuration)
+	RegistriesDirPath string
 
 	// === docker.Transport overrides ===
 	DockerCertPath              string // If not "", a directory containing "cert.pem" and "key.pem" used when talking to a Docker Registry

--- a/vendor/github.com/docker/distribution/reference/reference.go
+++ b/vendor/github.com/docker/distribution/reference/reference.go
@@ -24,6 +24,7 @@ package reference
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/docker/distribution/digest"
 )
@@ -42,6 +43,9 @@ var (
 
 	// ErrDigestInvalidFormat represents an error while trying to parse a string as a tag.
 	ErrDigestInvalidFormat = errors.New("invalid digest format")
+
+	// ErrNameContainsUppercase is returned for invalid repository names that contain uppercase characters.
+	ErrNameContainsUppercase = errors.New("repository name must be lowercase")
 
 	// ErrNameEmpty is returned for empty, invalid repository names.
 	ErrNameEmpty = errors.New("repository name must have at least one component")
@@ -149,7 +153,9 @@ func Parse(s string) (Reference, error) {
 		if s == "" {
 			return nil, ErrNameEmpty
 		}
-		// TODO(dmcgowan): Provide more specific and helpful error
+		if ReferenceRegexp.FindStringSubmatch(strings.ToLower(s)) != nil {
+			return nil, ErrNameContainsUppercase
+		}
 		return nil, ErrReferenceInvalidFormat
 	}
 


### PR DESCRIPTION
This vendors in unmerged https://github.com/containers/image/pull/52 and updates the API usage.  See the documentation in that PR for more details.