### PR TITLE
add support for completions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,11 @@
-.PHONY: all binary build-container build-local clean install install-binary shell test-integration
+.PHONY: all binary build-container build-local clean install install-binary install-completions shell test-integration
 
 export GO15VENDOREXPERIMENT=1
 
 PREFIX ?= ${DESTDIR}/usr
 INSTALLDIR=${PREFIX}/bin
 MANINSTALLDIR=${PREFIX}/share/man
-# TODO(runcom)
-#BASHINSTALLDIR=${PREFIX}/share/bash-completion/completions
+BASHINSTALLDIR=${PREFIX}/share/bash-completion/completions
 GO_MD2MAN ?= /usr/bin/go-md2man
 
 ifeq ($(DEBUG), 1)
@@ -60,9 +59,7 @@ docs: $(MANPAGES_MD:%.md=%)
 clean:
 	rm -f skopeo docs/*.1
 
-install: install-binary install-docs
-	# TODO(runcom)
-	#install -m 644 completion/bash/skopeo ${BASHINSTALLDIR}/
+install: install-binary install-docs install-completions
 
 install-binary: ./skopeo
 	install -d -m 0755 ${INSTALLDIR}
@@ -71,6 +68,9 @@ install-binary: ./skopeo
 install-docs: docs/skopeo.1
 	install -d -m 0755 ${MANINSTALLDIR}/man1
 	install -m 644 docs/skopeo.1 ${MANINSTALLDIR}/man1/
+
+install-completions:
+	install -m 644 -T hack/make/bash_autocomplete ${BASHINSTALLDIR}/skopeo
 
 shell: build-container
 	$(DOCKER_RUN_DOCKER) bash

--- a/cmd/skopeo/main.go
+++ b/cmd/skopeo/main.go
@@ -16,6 +16,7 @@ var gitCommit = ""
 // createApp returns a cli.App to be run or tested.
 func createApp() *cli.App {
 	app := cli.NewApp()
+	app.EnableBashCompletion = true
 	app.Name = "skopeo"
 	if gitCommit != "" {
 		app.Version = fmt.Sprintf("%s commit: %s", version.Version, gitCommit)

--- a/hack/make/bash_autocomplete
+++ b/hack/make/bash_autocomplete
@@ -1,0 +1,14 @@
+#! /bin/bash
+
+: ${PROG:=$(basename ${BASH_SOURCE})}
+
+_cli_bash_autocomplete() {
+     local cur opts base
+     COMPREPLY=()
+     cur="${COMP_WORDS[COMP_CWORD]}"
+     opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
+     COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+     return 0
+ }
+
+ complete -F _cli_bash_autocomplete $PROG


### PR DESCRIPTION
This PR adds the first level skopeo commands as bash auto completions.

Partially addresses issue #4 

This is to test the waters for the simple bash completions. Can add bash completion functions for skopeo command parameters and zsh completions (if folks want those too) in subsequent PR(s). 

Signed-off-by: Mike Brown <brownwm@us.ibm.com>