### PR TITLE
Docker lookaside tests

### DIFF
--- a/integration/fixtures/policy.json
+++ b/integration/fixtures/policy.json
@@ -6,6 +6,13 @@
     ],
     "transports": {
         "docker": {
+            "localhost:5555": [
+                {
+                    "type": "signedBy",
+                    "keyType": "GPGKeys",
+                    "keyPath": "@keydir@/personal-pubkey.gpg"
+                }
+            ],
             "docker.io/openshift": [
                 {
                     "type": "insecureAcceptAnything"

--- a/integration/fixtures/registries.yaml
+++ b/integration/fixtures/registries.yaml
@@ -1,0 +1,6 @@
+docker:
+   localhost:5555:
+        sigstore: file://@sigstore@
+   localhost:5555/public:
+        sigstore-staging: file://@split-staging@
+        sigstore: @split-read@

--- a/integration/registry.go
+++ b/integration/registry.go
@@ -67,6 +67,8 @@ loglevel: debug
 storage:
     filesystem:
         rootdirectory: %s
+    delete:
+        enabled: true
 http:
     addr: %s
 %s`


### PR DESCRIPTION
This includes https://github.com/projectatomic/skopeo/pull/170 , and adds integration tests for it.

Sadly, those tests depend on something like https://github.com/mtrmac/image/tree/docker-push-to-tag to support reasonable pushing to Docker registries, and that is not really ready. (Though perhaps it could be argued that it is better than status quo already?)