### PR TITLE
Add --remove-signatures to (skopeo copy)

### DIFF
--- a/cmd/skopeo/copy.go
+++ b/cmd/skopeo/copy.go
@@ -29,9 +29,11 @@ func copyHandler(context *cli.Context) error {
 		return fmt.Errorf("Invalid destination name %s: %v", context.Args()[1], err)
 	}
 	signBy := context.String("sign-by")
+	removeSignatures := context.Bool("remove-signatures")
 
 	return copy.Image(contextFromGlobalOptions(context), policyContext, destRef, srcRef, &copy.Options{
-		SignBy: signBy,
+		RemoveSignatures: removeSignatures,
+		SignBy:           signBy,
 	})
 }
 
@@ -42,6 +44,10 @@ var copyCmd = cli.Command{
 	Action:    copyHandler,
 	// FIXME: Do we need to namespace the GPG aspect?
 	Flags: []cli.Flag{
+		cli.BoolFlag{
+			Name:  "remove-signatures",
+			Usage: "Do not copy signatures from SOURCE-IMAGE",
+		},
 		cli.StringFlag{
 			Name:  "sign-by",
 			Usage: "Sign the image using a GPG key with the specified `FINGERPRINT`",

--- a/docs/skopeo.1.md
+++ b/docs/skopeo.1.md
@@ -65,6 +65,8 @@ Uses the system's signature verification policy to validate images, refuses to c
 
   _destination-image_ use the "image name" format described above
 
+  **--remove-signatures** do not copy signatures, if any, from _source-image_. Necessary when copying a signed image to a destination which does not support signatures. 
+
   **--sign-by=**_key-id_ add a signature using that key ID for an image name corresponding to _destination-image_
 
 Existing signatures, if any, are preserved as well.


### PR DESCRIPTION
This exposes https://github.com/containers/image/pull/68, and is necessary to allow copying signed images into destinations which don't support signatures.

(We could instead silently drop signatures when copying into such destinations, I think that is worse. `atomic pull` can easily hard-code `skopeo copy --remove-signatures docker://$source docker-daemon:$destination` when we know that `docker-daemon:` doesn’t support signatures; after we add such support, we would drop the option from `atomic`.)