### PR TITLE
Adds --policy-insecure-allow-anything flag

### DIFF
--- a/cmd/skopeo/main.go
+++ b/cmd/skopeo/main.go
@@ -32,6 +32,10 @@ func createApp() *cli.App {
 			Name:  "debug",
 			Usage: "enable debug output",
 		},
+		cli.BoolFlag{
+			Name:  "insecure-policy",
+			Usage: "run the tool without any policy check",
+		},
 		cli.StringFlag{
 			Name:  "username",
 			Value: "",
@@ -92,7 +96,9 @@ func getPolicyContext(c *cli.Context) (*signature.PolicyContext, error) {
 	policyPath := c.GlobalString("policy")
 	var policy *signature.Policy // This could be cached across calls, if we had an application context.
 	var err error
-	if policyPath == "" {
+	if c.GlobalBool("insecure-policy") {
+		policy = &signature.Policy{Default: []signature.PolicyRequirement{signature.NewPRInsecureAcceptAnything()}}
+	} else if policyPath == "" {
 		policy, err = signature.DefaultPolicy(nil)
 	} else {
 		policy, err = signature.NewPolicyFromFile(policyPath)


### PR DESCRIPTION
This patch adds a new flag --policy-insecure-allow-anything
Closes #181, we can now directly use the tool with the
above mentioned flag wihout using a policy file.

Signed-off-by: Kushal Das mail@kushaldas.in
