### PR TITLE
Create /etc/containers/registries.d in (make install)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ PREFIX ?= ${DESTDIR}/usr
 INSTALLDIR=${PREFIX}/bin
 MANINSTALLDIR=${PREFIX}/share/man
 CONTAINERSSYSCONFIGDIR=${DESTDIR}/etc/containers
+REGISTRIESDDIR=${CONTAINERSSYSCONFIGDIR}/registries.d
 BASHINSTALLDIR=${PREFIX}/share/bash-completion/completions
 GO_MD2MAN ?= /usr/bin/go-md2man
 
@@ -62,6 +63,7 @@ clean:
 
 install: install-binary install-docs install-completions
 	install -D -m 644 default-policy.json ${CONTAINERSSYSCONFIGDIR}/policy.json
+	install -d -m 755 ${REGISTRIESDDIR}
 
 install-binary: ./skopeo
 	install -D -m 755 skopeo ${INSTALLDIR}/skopeo


### PR DESCRIPTION
Per recent conversations; to make it easier to place the registries `.yaml` files into the correct place, and to avoid the question of what happens when the directory is missing.

Cc @lsm5 .