### PR TITLE
TLS verification in docker registries

### DIFF
--- a/cmd/skopeo/main.go
+++ b/cmd/skopeo/main.go
@@ -47,9 +47,9 @@ func createApp() *cli.App {
 			Value: "",
 			Usage: "use certificates at `PATH` (cert.pem, key.pem) to connect to the registry",
 		},
-		cli.BoolFlag{
+		cli.BoolTFlag{
 			Name:  "tls-verify",
-			Usage: "verify certificates",
+			Usage: "require HTTPS and verify certificates when talking to docker registries (defaults to true)",
 		},
 		cli.StringFlag{
 			Name:  "policy",

--- a/cmd/skopeo/utils.go
+++ b/cmd/skopeo/utils.go
@@ -8,7 +8,7 @@ import (
 
 // contextFromGlobalOptions returns a types.SystemContext depending on c.
 func contextFromGlobalOptions(c *cli.Context) *types.SystemContext {
-	tlsVerify := c.GlobalBool("tls-verify") // FIXME!! defaults to false
+	tlsVerify := c.GlobalBoolT("tls-verify")
 	return &types.SystemContext{
 		RegistriesDirPath:           c.GlobalString("registries.d"),
 		DockerCertPath:              c.GlobalString("cert-path"),

--- a/docs/skopeo.1.md
+++ b/docs/skopeo.1.md
@@ -47,7 +47,7 @@ Most commands refer to container images, using a _transport_`:`_details_ format.
 
   **--registries.d** _dir_ use registry configuration files in _dir_ (e.g. for docker signature storage), overriding the default path.
 
-  **--tls-verify** _bool-value_ Verify certificates
+  **--tls-verify** _bool-value_ Require HTTPS and verify certificates when talking to docker registries (defaults to true)
 
   **--help**|**-h** Show help
 

--- a/integration/check_test.go
+++ b/integration/check_test.go
@@ -96,7 +96,7 @@ func (s *SkopeoSuite) TestNeedAuthToPrivateRegistryV2WithoutDockerCfg(c *check.C
 // TODO(runcom): as soon as we can push to registries ensure you can inspect here
 // not just get image not found :)
 func (s *SkopeoSuite) TestNoNeedAuthToPrivateRegistryV2ImageNotFound(c *check.C) {
-	out, err := exec.Command(skopeoBinary, "inspect", fmt.Sprintf("docker://%s/busybox:latest", s.regV2.url)).CombinedOutput()
+	out, err := exec.Command(skopeoBinary, "--tls-verify=false", "inspect", fmt.Sprintf("docker://%s/busybox:latest", s.regV2.url)).CombinedOutput()
 	c.Assert(err, check.NotNil, check.Commentf(string(out)))
 	wanted := fmt.Sprintf(errFetchManifestRegexp, "404")
 	c.Assert(string(out), check.Matches, "(?s)"+wanted) // (?s) : '.' will also match newlines

--- a/vendor/github.com/containers/image/docker/docker_client.go
+++ b/vendor/github.com/containers/image/docker/docker_client.go
@@ -36,6 +36,7 @@ const (
 
 // dockerClient is configuration for dealing with a single Docker registry.
 type dockerClient struct {
+	ctx             *types.SystemContext
 	registry        string
 	username        string
 	password        string
@@ -85,6 +86,7 @@ func newDockerClient(ctx *types.SystemContext, ref dockerReference, write bool) 
 	}
 
 	return &dockerClient{
+		ctx:           ctx,
 		registry:      registry,
 		username:      username,
 		password:      password,
@@ -332,14 +334,9 @@ func (c *dockerClient) ping() (*pingResponse, error) {
 		}
 		return pr, nil
 	}
-	scheme := "https"
-	pr, err := ping(scheme)
-	if err != nil {
-		scheme = "http"
-		pr, err = ping(scheme)
-		if err == nil {
-			return pr, nil
-		}
+	pr, err := ping("https")
+	if err != nil && c.ctx.DockerInsecureSkipTLSVerify {
+		pr, err = ping("http")
 	}
 	return pr, err
 }

--- a/vendor/github.com/containers/image/types/types.go
+++ b/vendor/github.com/containers/image/types/types.go
@@ -201,5 +201,5 @@ type SystemContext struct {
 
 	// === docker.Transport overrides ===
 	DockerCertPath              string // If not "", a directory containing "cert.pem" and "key.pem" used when talking to a Docker Registry
-	DockerInsecureSkipTLSVerify bool
+	DockerInsecureSkipTLSVerify bool   // Allow contacting docker registries over HTTP, or HTTPS with failed TLS verification. Note that this does not affect other TLS connections.
 }


### PR DESCRIPTION
Depends on https://github.com/containers/image/pull/87 .

- Flip `--tls-verify` default to true    
- Document better what `--tls-verify` does
- ... and sprinkle `--tls-verify=false` over integration tests.

cc @baude