### PR TITLE
Bump to 0.1.15 and then again to 0.1.16-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ $ skopeo inspect docker://docker.io/fedora:rawhide | jq '.Digest'
 
 Copying images
 -
-`skopeo` can copy container images between various storage mechansism,
+`skopeo` can copy container images between various storage mechanisms,
 e.g. Docker registries (including the Docker Hub), the Atomic Registry,
 and local directories:
 

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.1.15"
+const Version = "0.1.16-dev"

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.1.14-dev"
+const Version = "0.1.15"


### PR DESCRIPTION
as soon as of all the deps are fixed /cc @mtrmac @rhatdan I'll tag https://github.com/projectatomic/skopeo/pull/217/commits/584f3c24e813b82805ef7933424424618c9d8155 as 0.1.15 once this is merged

/cc @lsm5 to rebuild on F25/Rawhide once I tag a new release