### PR TITLE
add sigstore default configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ INSTALLDIR=${PREFIX}/bin
 MANINSTALLDIR=${PREFIX}/share/man
 CONTAINERSSYSCONFIGDIR=${DESTDIR}/etc/containers
 REGISTRIESDDIR=${CONTAINERSSYSCONFIGDIR}/registries.d
+SIGSTOREDIR=${DESTDIR}/var/lib/atomic/sigstore
 BASHINSTALLDIR=${PREFIX}/share/bash-completion/completions
 GO_MD2MAN ?= /usr/bin/go-md2man
 
@@ -62,8 +63,9 @@ clean:
 	rm -f skopeo docs/*.1
 
 install: install-binary install-docs install-completions
+	install -d -m 755 ${SIGSTOREDIR}
 	install -D -m 644 default-policy.json ${CONTAINERSSYSCONFIGDIR}/policy.json
-	install -d -m 755 ${REGISTRIESDDIR}
+	install -D -m 644 default.yaml ${REGISTRIESDDIR}/default.yaml
 
 install-binary: ./skopeo
 	install -D -m 755 skopeo ${INSTALLDIR}/skopeo

--- a/default.yaml
+++ b/default.yaml
@@ -1,0 +1,26 @@
+# This is a default registries.d configuration file.  You may
+# add to this file or create additional files in registries.d/.
+#
+# sigstore: indicates a location that is read and write
+# sigstore-staging: indicates a location that is only for write
+#
+# sigstore and sigstore-staging take a value of the following:
+#   sigstore:  {schema}://location
+#
+# For reading signatures, schema may be http, https, or file.
+# For writing signatures, schema may only be file.
+
+# This is the default signature write location for docker registries.
+default-docker:
+#  sigstore: file:///var/lib/atomic/sigstore
+  sigstore-staging: file:///var/lib/atomic/sigstore
+
+# The 'docker' indicator here is the start of the configuration
+# for docker registries.
+#
+# docker:
+#
+#   privateregistry.com:
+#    sigstore: http://privateregistry.com/sigstore/
+#    sigstore-staging: /mnt/nfs/privateregistry/sigstore
+


### PR DESCRIPTION
@mtrmac @baude PTAL

We'll soon ship a skopeo sub-pkg which will just contain `/etc/containers/policy.json` and `/etc/containers/registries.d/default.yaml` so that docker (after projectatomic/docker#200) and atomic can require it in their spec w/o having N specs shipping those files.

Signed-off-by: Antonio Murdaca <runcom@redhat.com>