### PR TITLE
Fix skopeo layers and deprecate it

### DIFF
--- a/cmd/skopeo/layers.go
+++ b/cmd/skopeo/layers.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"io/ioutil"
 	"strings"
 
@@ -15,10 +16,13 @@ import (
 var layersCmd = cli.Command{
 	Name:      "layers",
 	Usage:     "Get layers of IMAGE-NAME",
-	ArgsUsage: "IMAGE-NAME",
+	ArgsUsage: "IMAGE-NAME [LAYER...]",
 	Action: func(c *cli.Context) error {
+		if c.NArg() == 0 {
+			return errors.New("please specify an image")
+		}
 		rawSource, err := parseImageSource(c, c.Args()[0], []string{
-			// TODO: skopeo layers only support these now
+			// TODO: skopeo layers only supports these now
 			// eventually we'll remove this command altogether...
 			manifest.DockerV2Schema1SignedMediaType,
 			manifest.DockerV2Schema1MediaType,

--- a/cmd/skopeo/layers.go
+++ b/cmd/skopeo/layers.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/containers/image/directory"
@@ -12,14 +14,14 @@ import (
 	"github.com/urfave/cli"
 )
 
-// TODO(runcom): document args and usage
 var layersCmd = cli.Command{
 	Name:      "layers",
 	Usage:     "Get layers of IMAGE-NAME",
 	ArgsUsage: "IMAGE-NAME [LAYER...]",
 	Action: func(c *cli.Context) error {
+		fmt.Fprintln(os.Stderr, `DEPRECATED: skopeo layers is deprecated in favor of skopeo copy`)
 		if c.NArg() == 0 {
-			return errors.New("please specify an image")
+			return errors.New("Usage: layers imageReference [layer...]")
 		}
 		rawSource, err := parseImageSource(c, c.Args()[0], []string{
 			// TODO: skopeo layers only supports these now


### PR DESCRIPTION
As title says. @mtrmac PTAL

@giuseppe I know you're using `skopeo layers` in your sys containers, would be nice to migrate that to `mkdir dir && skopeo copy docker://image_name dir:here_are_the_layers`