### PR TITLE
Add static compile target in Makefile

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,5 +1,5 @@
 FROM ubuntu:16.04
 RUN apt-get update
-RUN apt-get install -y golang git-core libgpgme11-dev
+RUN apt-get install -y golang git-core libgpgme11-dev go-md2man
 ENV GOPATH=/
 WORKDIR /src/github.com/projectatomic/skopeo


### PR DESCRIPTION
I want to run `skopeo` on CentOS with low glibc version, so static compile is better for me.

Signed-off-by: Ye Yin <eyniy@qq.com>