### PR TITLE
Do not merge: Pull in mtrmac/image:docker-daemon

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -6,7 +6,7 @@ rm -rf vendor/
 source 'hack/.vendor-helpers.sh'
 
 clone git github.com/urfave/cli v1.17.0
-clone git github.com/containers/image master
+clone git github.com/containers/image docker-daemon https://github.com/mtrmac/image
 clone git gopkg.in/cheggaaa/pb.v1 ad4efe000aa550bb54918c06ebbadc0ff17687b9 https://github.com/cheggaaa/pb
 clone git github.com/Sirupsen/logrus v0.10.0
 clone git github.com/go-check/check v1

--- a/vendor/github.com/containers/image/directory/directory_src.go
+++ b/vendor/github.com/containers/image/directory/directory_src.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
 )
 
@@ -29,17 +30,18 @@ func (s *dirImageSource) Reference() types.ImageReference {
 func (s *dirImageSource) Close() {
 }
 
-// it's up to the caller to determine the MIME type of the returned manifest's bytes
+// GetManifest returns the image's manifest along with its MIME type (which may be empty when it can't be determined but the manifest is available).
+// It may use a remote (= slow) service.
 func (s *dirImageSource) GetManifest() ([]byte, string, error) {
 	m, err := ioutil.ReadFile(s.ref.manifestPath())
 	if err != nil {
 		return nil, "", err
 	}
-	return m, "", err
+	return m, manifest.GuessMIMEType(m), err
 }
 
 func (s *dirImageSource) GetTargetManifest(digest string) ([]byte, string, error) {
-	return nil, "", fmt.Errorf("Getting target manifest not supported by dir:")
+	return nil, "", fmt.Errorf(`Getting target manifest not supported by "dir:"`)
 }
 
 // GetBlob returns a stream for the specified blob, and the blob’s size (or -1 if unknown).

--- a/vendor/github.com/containers/image/docker/daemon/daemon_dest.go
+++ b/vendor/github.com/containers/image/docker/daemon/daemon_dest.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/containers/image/docker/reference"
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
 	"github.com/docker/engine-api/client"
@@ -21,7 +22,8 @@ import (
 )
 
 type daemonImageDestination struct {
-	ref daemonReference
+	ref            daemonReference
+	namedTaggedRef reference.NamedTagged // Strictly speaking redundant with ref above; having the field makes it structurally impossible for later users to fail.
 	// For talking to imageLoadGoroutine
 	goroutineCancel context.CancelFunc
 	statusChannel   <-chan error
@@ -33,7 +35,14 @@ type daemonImageDestination struct {
 
 // newImageDestination returns a types.ImageDestination for the specified image reference.
 func newImageDestination(systemCtx *types.SystemContext, ref daemonReference) (types.ImageDestination, error) {
-	// FIXME: Do something with ref
+	if ref.ref == nil {
+		return nil, fmt.Errorf("Invalid destination docker-daemon:%s: a destination must be a name:tag", ref.StringWithinTransport())
+	}
+	namedTaggedRef, ok := ref.ref.(reference.NamedTagged)
+	if !ok {
+		return nil, fmt.Errorf("Invalid destination docker-daemon:%s: a destination must be a name:tag", ref.StringWithinTransport())
+	}
+
 	c, err := client.NewClient(client.DefaultDockerHost, "1.22", nil, nil) // FIXME: overridable host
 	if err != nil {
 		return nil, fmt.Errorf("Error initializing docker engine client: %v", err)
@@ -48,6 +57,7 @@ func newImageDestination(systemCtx *types.SystemContext, ref daemonReference) (t
 
 	return &daemonImageDestination{
 		ref:             ref,
+		namedTaggedRef:  namedTaggedRef,
 		goroutineCancel: goroutineCancel,
 		statusChannel:   statusChannel,
 		writer:          writer,
@@ -105,7 +115,7 @@ func (d *daemonImageDestination) Reference() types.ImageReference {
 // If an empty slice or nil it's returned, then any mime type can be tried to upload
 func (d *daemonImageDestination) SupportedManifestMIMETypes() []string {
 	return []string{
-		manifest.DockerV2Schema2MediaType, // FIXME: Handle others.
+		manifest.DockerV2Schema2MediaType, // We rely on the types.Image.UpdatedImage schema conversion capabilities.
 	}
 }
 
@@ -128,7 +138,7 @@ func (d *daemonImageDestination) ShouldCompressLayers() bool {
 // If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
 func (d *daemonImageDestination) PutBlob(stream io.Reader, inputInfo types.BlobInfo) (types.BlobInfo, error) {
 	if inputInfo.Digest == "" {
-		return types.BlobInfo{}, fmt.Errorf("Can not stream a blob with unknown digest to docker-daemon:")
+		return types.BlobInfo{}, fmt.Errorf(`"Can not stream a blob with unknown digest to "docker-daemon:"`)
 	}
 
 	if inputInfo.Size == -1 { // Ouch, we need to stream the blob into a temporary file just to determine the size.
@@ -167,7 +177,6 @@ func (d *daemonImageDestination) PutManifest(m []byte) error {
 		return fmt.Errorf("Error parsing manifest: %v", err)
 	}
 	if man.SchemaVersion != 2 || man.MediaType != manifest.DockerV2Schema2MediaType {
-		// FIXME FIXME: Teach copy.go about this.
 		return fmt.Errorf("Unsupported manifest type, need a Docker schema 2 manifest")
 	}
 
@@ -175,9 +184,28 @@ func (d *daemonImageDestination) PutManifest(m []byte) error {
 	for _, l := range man.Layers {
 		layerPaths = append(layerPaths, l.Digest)
 	}
+
+	// For github.com/docker/docker consumers, this works just as well as
+	//   refString := d.namedTaggedRef.String()  [i.e. d.ref.ref.String()]
+	// because when reading the RepoTags strings, github.com/docker/docker/reference
+	// normalizes both of them to the same value.
+	//
+	// Doing it this way to include the normalized-out `docker.io[/library]` does make
+	// a difference for github.com/projectatomic/docker consumers, with the
+	// “Add --add-registry and --block-registry options to docker daemon” patch.
+	// These consumers treat reference strings which include a hostname and reference
+	// strings without a hostname differently.
+	//
+	// Using the host name here is more explicit about the intent, and it has the same
+	// effect as (docker pull) in projectatomic/docker, which tags the result using
+	// a hostname-qualified reference.
+	// See https://github.com/containers/image/issues/72 for a more detailed
+	// analysis and explanation.
+	refString := fmt.Sprintf("%s:%s", d.namedTaggedRef.FullName(), d.namedTaggedRef.Tag())
+
 	items := []manifestItem{{
 		Config:       man.Config.Digest,
-		RepoTags:     []string{string(d.ref)}, // FIXME: Only if ref is a NamedTagged
+		RepoTags:     []string{refString},
 		Layers:       layerPaths,
 		Parent:       "",
 		LayerSources: nil,

--- a/vendor/github.com/containers/image/docker/daemon/daemon_transport.go
+++ b/vendor/github.com/containers/image/docker/daemon/daemon_transport.go
@@ -1,10 +1,13 @@
 package daemon
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/containers/image/docker/reference"
+	"github.com/containers/image/image"
 	"github.com/containers/image/types"
+	"github.com/docker/distribution/digest"
 )
 
 // Transport is an ImageTransport for images managed by a local Docker daemon.
@@ -27,19 +30,69 @@ func (t daemonTransport) ParseReference(reference string) (types.ImageReference,
 // It is acceptable to allow an invalid value which will never be matched, it can "only" cause user confusion.
 // scope passed to this function will not be "", that value is always allowed.
 func (t daemonTransport) ValidatePolicyConfigurationScope(scope string) error {
-	// FIXME FIXME
-	return nil
+	// See the explanation in daemonReference.PolicyConfigurationIdentity.
+	return errors.New(`docker-daemon: does not support any scopes except the default "" one`)
 }
 
-// daemonReference is an ImageReference for images managed by a local Docker daemon.
-type daemonReference string // FIXME FIXME
+// daemonReference is an ImageReference for images managed by a local Docker daemon
+// Exactly one of id and ref can be set.
+// For daemonImageSource, both id and ref are acceptable, ref must not be a NameOnly (interpreted as all tags in that repository by the daemon)
+// For daemonImageDestination, it must be a ref, which is NamedTagged.
+// (We could, in principle, also allow storing images without tagging them, and the user would have to refer to them using the docker image ID = config digest.
+//  Using the config digest requires the caller to parse the manifest themselves, which is very cumbersome; so, for now, we don’t bother.)
+type daemonReference struct {
+	id  digest.Digest
+	ref reference.Named // !reference.IsNameOnly
+}
 
 // ParseReference converts a string, which should not start with the ImageTransport.Name prefix, into an ImageReference.
-func ParseReference(reference string) (types.ImageReference, error) {
-	return daemonReference(reference), nil // FIXME FIXME
+func ParseReference(refString string) (types.ImageReference, error) {
+	// This is intended to be compatible with reference.ParseIDOrReference, but more strict about refusing some of the ambiguous cases.
+	// In particular, this rejects unprefixed digest values (64 hex chars), and sha256 digest prefixes (sha256:fewer-than-64-hex-chars).
+
+	// digest:hexstring is structurally the same as a reponame:tag (meaning docker.io/library/reponame:tag).
+	// reference.ParseIDOrReference interprets such strings as digests.
+	if dgst, err := digest.ParseDigest(refString); err == nil {
+		// The daemon explicitly refuses to tag images with a reponame equal to digest.Canonical - but _only_ this digest name.
+		// Other digest references are ambiguous, so refuse them.
+		if dgst.Algorithm() != digest.Canonical {
+			return nil, fmt.Errorf("Invalid docker-daemon: reference %s: only digest algorithm %s accepted", refString, digest.Canonical)
+		}
+		return NewReference(dgst, nil)
+	}
+
+	ref, err := reference.ParseNamed(refString) // This also rejects unprefixed digest values
+	if err != nil {
+		return nil, err
+	}
+	if ref.Name() == digest.Canonical.String() {
+		return nil, fmt.Errorf("Invalid docker-daemon: reference %s: The %s repository name is reserved for (non-shortened) digest references", refString, digest.Canonical)
+	}
+	return NewReference("", ref)
 }
 
-// FIXME FIXME: NewReference?
+// NewReference returns a docker-daemon reference for either the supplied image ID (config digest) or the supplied reference (which must satisfy !reference.IsNameOnly)
+func NewReference(id digest.Digest, ref reference.Named) (types.ImageReference, error) {
+	if id != "" && ref != nil {
+		return nil, errors.New("docker-daemon: reference must not have an image ID and a reference string specified at the same time")
+	}
+	if ref != nil {
+		if reference.IsNameOnly(ref) {
+			return nil, fmt.Errorf("docker-daemon: reference %s has neither a tag nor a digest", ref.String())
+		}
+		// A github.com/distribution/reference value can have a tag and a digest at the same time!
+		// docker/reference does not handle that, so fail.
+		_, isTagged := ref.(reference.NamedTagged)
+		_, isDigested := ref.(reference.Canonical)
+		if isTagged && isDigested {
+			return nil, fmt.Errorf("docker-daemon: references with both a tag and digest are currently not supported")
+		}
+	}
+	return daemonReference{
+		id:  id,
+		ref: ref,
+	}, nil
+}
 
 func (ref daemonReference) Transport() types.ImageTransport {
 	return Transport
@@ -52,14 +105,21 @@ func (ref daemonReference) Transport() types.ImageTransport {
 // WARNING: Do not use the return value in the UI to describe an image, it does not contain the Transport().Name() prefix;
 // instead, see transports.ImageName().
 func (ref daemonReference) StringWithinTransport() string {
-	return string(ref) // FIXME FIXME
+	switch {
+	case ref.id != "":
+		return ref.id.String()
+	case ref.ref != nil:
+		return ref.ref.String()
+	default: // Coverage: Should never happen, NewReference above should refuse such values.
+		panic("Internal inconsistency: daemonReference has empty id and nil ref")
+	}
 }
 
 // DockerReference returns a Docker reference associated with this reference
 // (fully explicit, i.e. !reference.IsNameOnly, but reflecting user intent,
 // not e.g. after redirect or alias processing), or nil if unknown/not applicable.
 func (ref daemonReference) DockerReference() reference.Named {
-	return nil // FIXME FIXME
+	return ref.ref // May be nil
 }
 
 // PolicyConfigurationIdentity returns a string representation of the reference, suitable for policy lookup.
@@ -70,7 +130,10 @@ func (ref daemonReference) DockerReference() reference.Named {
 // not required/guaranteed that it will be a valid input to Transport().ParseReference().
 // Returns "" if configuration identities for these references are not supported.
 func (ref daemonReference) PolicyConfigurationIdentity() string {
-	return string(ref) // FIXME FIXME
+	// We must allow referring to images in the daemon by image ID, otherwise untagged images would not be accessible.
+	// But the existence of image IDs means that we can’t truly well namespace the input; the untagged images would have to fall into the default policy,
+	// which can be unexpected.  So, punt.
+	return "" // This still allows using the default "" scope to define a policy for this transport.
 }
 
 // PolicyConfigurationNamespaces returns a list of other policy configuration namespaces to search
@@ -79,13 +142,18 @@ func (ref daemonReference) PolicyConfigurationIdentity() string {
 // It is STRONGLY recommended for the first element, if any, to be a prefix of PolicyConfigurationIdentity(),
 // and each following element to be a prefix of the element preceding it.
 func (ref daemonReference) PolicyConfigurationNamespaces() []string {
-	return []string{} // FIXME FIXME?
+	// See the explanation in daemonReference.PolicyConfigurationIdentity.
+	return []string{}
 }
 
 // NewImage returns a types.Image for this reference.
 // The caller must call .Close() on the returned Image.
 func (ref daemonReference) NewImage(ctx *types.SystemContext) (types.Image, error) {
-	panic("FIXME FIXME")
+	src, err := newImageSource(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
+	return image.FromSource(src)
 }
 
 // NewImageSource returns a types.ImageSource for this reference,
@@ -104,5 +172,8 @@ func (ref daemonReference) NewImageDestination(ctx *types.SystemContext) (types.
 
 // DeleteImage deletes the named image from the registry, if supported.
 func (ref daemonReference) DeleteImage(ctx *types.SystemContext) error {
-	return fmt.Errorf("Deleting images not implemented for docker-daemon: images") // FIXME FIXME?
+	// Should this just untag the image? Should this stop running containers?
+	// The semantics is not quite as clear as for remote repositories.
+	// The user can run (docker rmi) directly anyway, so, for now(?), punt instead of trying to guess what the user meant.
+	return fmt.Errorf("Deleting images not implemented for docker-daemon: images")
 }

--- a/vendor/github.com/containers/image/docker/daemon/daemon_types.go
+++ b/vendor/github.com/containers/image/docker/daemon/daemon_types.go
@@ -41,7 +41,7 @@ type schema2Manifest struct {
 
 // Based on github.com/docker/docker/image/image.go
 // MOST CONTENT OMITTED AS UNNECESSARY
-type image struct {
+type dockerImage struct {
 	RootFS *rootFS `json:"rootfs,omitempty"`
 }
 

--- a/vendor/github.com/containers/image/docker/docker_image_dest.go
+++ b/vendor/github.com/containers/image/docker/docker_image_dest.go
@@ -263,7 +263,7 @@ func (d *dockerImageDestination) putOneSignature(url *url.URL, signature []byte)
 		return nil
 
 	case "http", "https":
-		return fmt.Errorf("Writing directly to a %s sigstore %s is not supported. Configure a sigstore-staging: location.", url.Scheme, url.String())
+		return fmt.Errorf("Writing directly to a %s sigstore %s is not supported. Configure a sigstore-staging: location", url.Scheme, url.String())
 	default:
 		return fmt.Errorf("Unsupported scheme when writing signature to %s", url.String())
 	}
@@ -282,7 +282,7 @@ func (c *dockerClient) deleteOneSignature(url *url.URL) (missing bool, err error
 		return false, err
 
 	case "http", "https":
-		return false, fmt.Errorf("Writing directly to a %s sigstore %s is not supported. Configure a sigstore-staging: location.", url.Scheme, url.String())
+		return false, fmt.Errorf("Writing directly to a %s sigstore %s is not supported. Configure a sigstore-staging: location", url.Scheme, url.String())
 	default:
 		return false, fmt.Errorf("Unsupported scheme when deleting signature from %s", url.String())
 	}

--- a/vendor/github.com/containers/image/docker/docker_image_src.go
+++ b/vendor/github.com/containers/image/docker/docker_image_src.go
@@ -67,6 +67,8 @@ func simplifyContentType(contentType string) string {
 	return mimeType
 }
 
+// GetManifest returns the image's manifest along with its MIME type (which may be empty when it can't be determined but the manifest is available).
+// It may use a remote (= slow) service.
 func (s *dockerImageSource) GetManifest() ([]byte, string, error) {
 	err := s.ensureManifestIsLoaded()
 	if err != nil {
@@ -244,7 +246,7 @@ func deleteImage(ctx *types.SystemContext, ref dockerReference) error {
 	switch get.StatusCode {
 	case http.StatusOK:
 	case http.StatusNotFound:
-		return fmt.Errorf("Unable to delete %v. Image may not exist or is not stored with a v2 Schema in a v2 registry.", ref.ref)
+		return fmt.Errorf("Unable to delete %v. Image may not exist or is not stored with a v2 Schema in a v2 registry", ref.ref)
 	default:
 		return fmt.Errorf("Failed to delete %v: %s (%v)", ref.ref, manifestBody, get.Status)
 	}

--- a/vendor/github.com/containers/image/image/docker_schema1.go
+++ b/vendor/github.com/containers/image/image/docker_schema1.go
@@ -54,16 +54,19 @@ func manifestSchema1FromManifest(manifest []byte) (genericManifest, error) {
 	if err := json.Unmarshal(manifest, mschema1); err != nil {
 		return nil, err
 	}
+	if mschema1.SchemaVersion != 1 {
+		return nil, fmt.Errorf("unsupported schema version %d", mschema1.SchemaVersion)
+	}
+	if len(mschema1.FSLayers) != len(mschema1.History) {
+		return nil, errors.New("length of history not equal to number of layers")
+	}
+	if len(mschema1.FSLayers) == 0 {
+		return nil, errors.New("no FSLayers in manifest")
+	}
+
 	if err := fixManifestLayers(mschema1); err != nil {
 		return nil, err
 	}
-	// TODO(runcom): verify manifest schema 1, 2 etc
-	//if len(m.FSLayers) != len(m.History) {
-	//return nil, fmt.Errorf("length of history not equal to number of layers for %q", ref.String())
-	//}
-	//if len(m.FSLayers) == 0 {
-	//return nil, fmt.Errorf("no FSLayers in manifest for %q", ref.String())
-	//}
 	return mschema1, nil
 }
 
@@ -201,7 +204,7 @@ func fixManifestLayers(manifest *manifestSchema1) error {
 		}
 	}
 	if imgs[len(imgs)-1].Parent != "" {
-		return errors.New("Invalid parent ID in the base layer of the image.")
+		return errors.New("Invalid parent ID in the base layer of the image")
 	}
 	// check general duplicates to error instead of a deadlock
 	idmap := make(map[string]struct{})
@@ -220,7 +223,7 @@ func fixManifestLayers(manifest *manifestSchema1) error {
 			manifest.FSLayers = append(manifest.FSLayers[:i], manifest.FSLayers[i+1:]...)
 			manifest.History = append(manifest.History[:i], manifest.History[i+1:]...)
 		} else if imgs[i].Parent != imgs[i+1].ID {
-			return fmt.Errorf("Invalid parent ID. Expected %v, got %v.", imgs[i+1].ID, imgs[i].Parent)
+			return fmt.Errorf("Invalid parent ID. Expected %v, got %v", imgs[i+1].ID, imgs[i].Parent)
 		}
 	}
 	return nil

--- a/vendor/github.com/containers/image/image/manifest.go
+++ b/vendor/github.com/containers/image/image/manifest.go
@@ -1,14 +1,13 @@
 package image
 
 import (
-	"errors"
-	"fmt"
 	"time"
 
 	"github.com/docker/engine-api/types/strslice"
 
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 type config struct {
@@ -86,14 +85,23 @@ func manifestInstanceFromBlob(src types.ImageSource, manblob []byte, mt string) 
 	// need to happen within the ImageSource.
 	case manifest.DockerV2Schema1MediaType, manifest.DockerV2Schema1SignedMediaType, "application/json":
 		return manifestSchema1FromManifest(manblob)
-	case manifest.DockerV2Schema2MediaType:
+	case manifest.DockerV2Schema2MediaType, imgspecv1.MediaTypeImageManifest:
+		// FIXME: OCI v1 is compatible with Docker Schema2, "docker_schema2.go" is good enough for reading images, but this will
+		// need to be modified for write support due to differing MIME types.
 		return manifestSchema2FromManifest(src, manblob)
 	case manifest.DockerV2ListMediaType:
 		return manifestSchema2FromManifestList(src, manblob)
-	case "":
-		return nil, errors.New("could not guess manifest media type")
 	default:
-		return nil, fmt.Errorf("unsupported manifest media type %s", mt)
+		// If it's not a recognized manifest media type, or we have failed determining the type, we'll try one last time
+		// to deserialize using v2s1 as per https://github.com/docker/distribution/blob/master/manifests.go#L108
+		// and https://github.com/docker/distribution/blob/master/manifest/schema1/manifest.go#L50
+		//
+		// Crane registries can also return "text/plain", or pretty much anything else depending on a file extension “recognized” in the tag.
+		// This makes no real sense, but it happens
+		// because requests for manifests are
+		// redirected to a content distribution
+		// network which is configured that way. See https://bugzilla.redhat.com/show_bug.cgi?id=1389442
+		return manifestSchema1FromManifest(manblob)
 	}
 }
 

--- a/vendor/github.com/containers/image/image/sourced.go
+++ b/vendor/github.com/containers/image/image/sourced.go
@@ -57,14 +57,6 @@ func FromUnparsedImage(unparsed *UnparsedImage) (types.Image, error) {
 	if err != nil {
 		return nil, err
 	}
-	if manifestMIMEType == "" || manifestMIMEType == "text/plain" {
-		// Crane registries can return "text/plain".
-		// This makes no real sense, but it happens
-		// because requests for manifests are
-		// redirected to a content distribution
-		// network which is configured that way.
-		manifestMIMEType = manifest.GuessMIMEType(manifestBlob)
-	}
 
 	parsedManifest, err := manifestInstanceFromBlob(unparsed.src, manifestBlob, manifestMIMEType)
 	if err != nil {
@@ -79,7 +71,7 @@ func FromUnparsedImage(unparsed *UnparsedImage) (types.Image, error) {
 	}, nil
 }
 
-// Manifest overrides the UnparsedImage.Manifest to use the fields which we have already fetched, after guessing and overrides.
+// Manifest overrides the UnparsedImage.Manifest to always use the fields which we have already fetched.
 func (i *sourcedImage) Manifest() ([]byte, string, error) {
 	return i.manifestBlob, i.manifestMIMEType, nil
 }

--- a/vendor/github.com/containers/image/oci/layout/oci_src.go
+++ b/vendor/github.com/containers/image/oci/layout/oci_src.go
@@ -1,0 +1,93 @@
+package layout
+
+import (
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"os"
+
+	"github.com/containers/image/manifest"
+	"github.com/containers/image/types"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+type ociImageSource struct {
+	ref ociReference
+}
+
+// newImageSource returns an ImageSource for reading from an existing directory.
+func newImageSource(ref ociReference) types.ImageSource {
+	return &ociImageSource{ref: ref}
+}
+
+// Reference returns the reference used to set up this source.
+func (s *ociImageSource) Reference() types.ImageReference {
+	return s.ref
+}
+
+// Close removes resources associated with an initialized ImageSource, if any.
+func (s *ociImageSource) Close() {
+}
+
+// GetManifest returns the image's manifest along with its MIME type (which may be empty when it can't be determined but the manifest is available).
+// It may use a remote (= slow) service.
+func (s *ociImageSource) GetManifest() ([]byte, string, error) {
+	descriptorPath := s.ref.descriptorPath(s.ref.tag)
+	data, err := ioutil.ReadFile(descriptorPath)
+	if err != nil {
+		return nil, "", err
+	}
+
+	desc := imgspecv1.Descriptor{}
+	err = json.Unmarshal(data, &desc)
+	if err != nil {
+		return nil, "", err
+	}
+
+	manifestPath, err := s.ref.blobPath(desc.Digest)
+	if err != nil {
+		return nil, "", err
+	}
+	m, err := ioutil.ReadFile(manifestPath)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return m, manifest.GuessMIMEType(m), nil
+}
+
+func (s *ociImageSource) GetTargetManifest(digest string) ([]byte, string, error) {
+	manifestPath, err := s.ref.blobPath(digest)
+	if err != nil {
+		return nil, "", err
+	}
+
+	m, err := ioutil.ReadFile(manifestPath)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return m, manifest.GuessMIMEType(m), nil
+}
+
+// GetBlob returns a stream for the specified blob, and the blob's size.
+func (s *ociImageSource) GetBlob(digest string) (io.ReadCloser, int64, error) {
+	path, err := s.ref.blobPath(digest)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	r, err := os.Open(path)
+	if err != nil {
+		return nil, 0, err
+	}
+	fi, err := r.Stat()
+	if err != nil {
+		return nil, 0, err
+	}
+	return r, fi.Size(), nil
+}
+
+func (s *ociImageSource) GetSignatures() ([][]byte, error) {
+	return [][]byte{}, nil
+}

--- a/vendor/github.com/containers/image/oci/layout/oci_transport.go
+++ b/vendor/github.com/containers/image/oci/layout/oci_transport.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/containers/image/directory/explicitfilepath"
 	"github.com/containers/image/docker/reference"
+	"github.com/containers/image/image"
 	"github.com/containers/image/types"
 )
 
@@ -169,7 +170,8 @@ func (ref ociReference) PolicyConfigurationNamespaces() []string {
 // NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
 // verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
 func (ref ociReference) NewImage(ctx *types.SystemContext) (types.Image, error) {
-	return nil, errors.New("Full Image support not implemented for oci: image names")
+	src := newImageSource(ref)
+	return image.FromSource(src)
 }
 
 // NewImageSource returns a types.ImageSource for this reference,
@@ -177,7 +179,7 @@ func (ref ociReference) NewImage(ctx *types.SystemContext) (types.Image, error) 
 // nil requestedManifestMIMETypes means manifest.DefaultRequestedManifestMIMETypes.
 // The caller must call .Close() on the returned ImageSource.
 func (ref ociReference) NewImageSource(ctx *types.SystemContext, requestedManifestMIMETypes []string) (types.ImageSource, error) {
-	return nil, errors.New("Reading images not implemented for oci: image names")
+	return newImageSource(ref), nil
 }
 
 // NewImageDestination returns a types.ImageDestination for this reference.

--- a/vendor/github.com/containers/image/openshift/openshift.go
+++ b/vendor/github.com/containers/image/openshift/openshift.go
@@ -203,6 +203,8 @@ func (s *openshiftImageSource) GetTargetManifest(digest string) ([]byte, string,
 	return s.docker.GetTargetManifest(digest)
 }
 
+// GetManifest returns the image's manifest along with its MIME type (which may be empty when it can't be determined but the manifest is available).
+// It may use a remote (= slow) service.
 func (s *openshiftImageSource) GetManifest() ([]byte, string, error) {
 	if err := s.ensureImageIsResolved(); err != nil {
 		return nil, "", err

--- a/vendor/github.com/containers/image/signature/policy_reference_match.go
+++ b/vendor/github.com/containers/image/signature/policy_reference_match.go
@@ -36,6 +36,29 @@ func (prm *prmMatchExact) matchesDockerReference(image types.UnparsedImage, sign
 	return signature.String() == intended.String()
 }
 
+func (prm *prmMatchRepoDigestOrExact) matchesDockerReference(image types.UnparsedImage, signatureDockerReference string) bool {
+	intended, signature, err := parseImageAndDockerReference(image, signatureDockerReference)
+	if err != nil {
+		return false
+	}
+
+	// Do not add default tags: image.Reference().DockerReference() should contain it already, and signatureDockerReference should be exact; so, verify that now.
+	if reference.IsNameOnly(signature) {
+		return false
+	}
+	switch intended.(type) {
+	case reference.NamedTagged: // Includes the case when intended has both a tag and a digest.
+		return signature.String() == intended.String()
+	case reference.Canonical:
+		// We don’t actually compare the manifest digest against the signature here; that happens prSignedBy.in UnparsedImage.Manifest.
+		// Becase UnparsedImage.Manifest verifies the intended.Digest() against the manifest, and prSignedBy verifies the signature digest against the manifest,
+		// we know that signature digest matches intended.Digest() (but intended.Digest() and signature digest may use different algorithms)
+		return signature.Name() == intended.Name()
+	default: // !reference.IsNameOnly(intended)
+		return false
+	}
+}
+
 func (prm *prmMatchRepository) matchesDockerReference(image types.UnparsedImage, signatureDockerReference string) bool {
 	intended, signature, err := parseImageAndDockerReference(image, signatureDockerReference)
 	if err != nil {

--- a/vendor/github.com/containers/image/signature/policy_types.go
+++ b/vendor/github.com/containers/image/signature/policy_types.go
@@ -116,14 +116,21 @@ type prmCommon struct {
 type prmTypeIdentifier string
 
 const (
-	prmTypeMatchExact      prmTypeIdentifier = "matchExact"
-	prmTypeMatchRepository prmTypeIdentifier = "matchRepository"
-	prmTypeExactReference  prmTypeIdentifier = "exactReference"
-	prmTypeExactRepository prmTypeIdentifier = "exactRepository"
+	prmTypeMatchExact             prmTypeIdentifier = "matchExact"
+	prmTypeMatchRepoDigestOrExact prmTypeIdentifier = "matchRepoDigestOrExact"
+	prmTypeMatchRepository        prmTypeIdentifier = "matchRepository"
+	prmTypeExactReference         prmTypeIdentifier = "exactReference"
+	prmTypeExactRepository        prmTypeIdentifier = "exactRepository"
 )
 
 // prmMatchExact is a PolicyReferenceMatch with type = prmMatchExact: the two references must match exactly.
 type prmMatchExact struct {
+	prmCommon
+}
+
+// prmMatchRepoDigestOrExact is a PolicyReferenceMatch with type = prmMatchExactOrDigest: the two references must match exactly,
+// except that digest references are also accepted if the repository name matches (regardless of tag/digest) and the signature applies to the referenced digest
+type prmMatchRepoDigestOrExact struct {
 	prmCommon
 }
 

--- a/vendor/github.com/containers/image/types/types.go
+++ b/vendor/github.com/containers/image/types/types.go
@@ -108,7 +108,7 @@ type ImageSource interface {
 	Reference() ImageReference
 	// Close removes resources associated with an initialized ImageSource, if any.
 	Close()
-	// GetManifest returns the image's manifest along with its MIME type. The empty string is returned if the MIME type is unknown.
+	// GetManifest returns the image's manifest along with its MIME type (which may be empty when it can't be determined but the manifest is available).
 	// It may use a remote (= slow) service.
 	GetManifest() ([]byte, string, error)
 	// GetTargetManifest returns an image's manifest given a digest. This is mainly used to retrieve a single image's manifest

--- a/vendor/github.com/davecgh/go-spew/LICENSE
+++ b/vendor/github.com/davecgh/go-spew/LICENSE
@@ -1,6 +1,6 @@
 ISC License
 
-Copyright (c) 2012-2013 Dave Collins <dave@davec.name>
+Copyright (c) 2012-2016 Dave Collins <dave@davec.name>
 
 Permission to use, copy, modify, and distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/vendor/github.com/davecgh/go-spew/spew/bypass.go
+++ b/vendor/github.com/davecgh/go-spew/spew/bypass.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Dave Collins <dave@davec.name>
+// Copyright (c) 2015-2016 Dave Collins <dave@davec.name>
 //
 // Permission to use, copy, modify, and distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above

--- a/vendor/github.com/davecgh/go-spew/spew/bypasssafe.go
+++ b/vendor/github.com/davecgh/go-spew/spew/bypasssafe.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 Dave Collins <dave@davec.name>
+// Copyright (c) 2015-2016 Dave Collins <dave@davec.name>
 //
 // Permission to use, copy, modify, and distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above

--- a/vendor/github.com/davecgh/go-spew/spew/common.go
+++ b/vendor/github.com/davecgh/go-spew/spew/common.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013 Dave Collins <dave@davec.name>
+ * Copyright (c) 2013-2016 Dave Collins <dave@davec.name>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above

--- a/vendor/github.com/davecgh/go-spew/spew/config.go
+++ b/vendor/github.com/davecgh/go-spew/spew/config.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013 Dave Collins <dave@davec.name>
+ * Copyright (c) 2013-2016 Dave Collins <dave@davec.name>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -66,6 +66,15 @@ type ConfigState struct {
 	// running in environments without access to the unsafe package such as
 	// Google App Engine or with the "safe" build tag specified.
 	DisablePointerMethods bool
+
+	// DisablePointerAddresses specifies whether to disable the printing of
+	// pointer addresses. This is useful when diffing data structures in tests.
+	DisablePointerAddresses bool
+
+	// DisableCapacities specifies whether to disable the printing of capacities
+	// for arrays, slices, maps and channels. This is useful when diffing
+	// data structures in tests.
+	DisableCapacities bool
 
 	// ContinueOnMethod specifies whether or not recursion should continue once
 	// a custom error or Stringer interface is invoked.  The default, false,

--- a/vendor/github.com/davecgh/go-spew/spew/doc.go
+++ b/vendor/github.com/davecgh/go-spew/spew/doc.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013 Dave Collins <dave@davec.name>
+ * Copyright (c) 2013-2016 Dave Collins <dave@davec.name>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -90,6 +90,15 @@ The following configuration options are available:
 		Disables invocation of error and Stringer interface methods on types
 		which only accept pointer receivers from non-pointer variables.
 		Pointer method invocation is enabled by default.
+
+	* DisablePointerAddresses
+		DisablePointerAddresses specifies whether to disable the printing of
+		pointer addresses. This is useful when diffing data structures in tests.
+
+	* DisableCapacities
+		DisableCapacities specifies whether to disable the printing of
+		capacities for arrays, slices, maps and channels. This is useful when
+		diffing data structures in tests.
 
 	* ContinueOnMethod
 		Enables recursion into types after invoking error and Stringer interface

--- a/vendor/github.com/davecgh/go-spew/spew/dump.go
+++ b/vendor/github.com/davecgh/go-spew/spew/dump.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013 Dave Collins <dave@davec.name>
+ * Copyright (c) 2013-2016 Dave Collins <dave@davec.name>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -129,7 +129,7 @@ func (d *dumpState) dumpPtr(v reflect.Value) {
 	d.w.Write(closeParenBytes)
 
 	// Display pointer information.
-	if len(pointerChain) > 0 {
+	if !d.cs.DisablePointerAddresses && len(pointerChain) > 0 {
 		d.w.Write(openParenBytes)
 		for i, addr := range pointerChain {
 			if i > 0 {
@@ -282,13 +282,13 @@ func (d *dumpState) dump(v reflect.Value) {
 	case reflect.Map, reflect.String:
 		valueLen = v.Len()
 	}
-	if valueLen != 0 || valueCap != 0 {
+	if valueLen != 0 || !d.cs.DisableCapacities && valueCap != 0 {
 		d.w.Write(openParenBytes)
 		if valueLen != 0 {
 			d.w.Write(lenEqualsBytes)
 			printInt(d.w, int64(valueLen), 10)
 		}
-		if valueCap != 0 {
+		if !d.cs.DisableCapacities && valueCap != 0 {
 			if valueLen != 0 {
 				d.w.Write(spaceBytes)
 			}

--- a/vendor/github.com/davecgh/go-spew/spew/format.go
+++ b/vendor/github.com/davecgh/go-spew/spew/format.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013 Dave Collins <dave@davec.name>
+ * Copyright (c) 2013-2016 Dave Collins <dave@davec.name>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above

--- a/vendor/github.com/davecgh/go-spew/spew/spew.go
+++ b/vendor/github.com/davecgh/go-spew/spew/spew.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013 Dave Collins <dave@davec.name>
+ * Copyright (c) 2013-2016 Dave Collins <dave@davec.name>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above

--- a/vendor/github.com/go-check/check/check.go
+++ b/vendor/github.com/go-check/check/check.go
@@ -156,7 +156,7 @@ func (td *tempDir) newPath() string {
 		}
 	}
 	result := filepath.Join(td.path, strconv.Itoa(td.counter))
-	td.counter += 1
+	td.counter++
 	return result
 }
 
@@ -274,7 +274,7 @@ func (c *C) logString(issue string) {
 
 func (c *C) logCaller(skip int) {
 	// This is a bit heavier than it ought to be.
-	skip += 1 // Our own frame.
+	skip++ // Our own frame.
 	pc, callerFile, callerLine, ok := runtime.Caller(skip)
 	if !ok {
 		return
@@ -284,7 +284,7 @@ func (c *C) logCaller(skip int) {
 	testFunc := runtime.FuncForPC(c.method.PC())
 	if runtime.FuncForPC(pc) != testFunc {
 		for {
-			skip += 1
+			skip++
 			if pc, file, line, ok := runtime.Caller(skip); ok {
 				// Note that the test line may be different on
 				// distinct calls for the same test.  Showing
@@ -460,10 +460,10 @@ func (tracker *resultTracker) _loopRoutine() {
 			// Calls still running. Can't stop.
 			select {
 			// XXX Reindent this (not now to make diff clear)
-			case c = <-tracker._expectChan:
-				tracker._waiting += 1
+			case <-tracker._expectChan:
+				tracker._waiting++
 			case c = <-tracker._doneChan:
-				tracker._waiting -= 1
+				tracker._waiting--
 				switch c.status() {
 				case succeededSt:
 					if c.kind == testKd {
@@ -498,9 +498,9 @@ func (tracker *resultTracker) _loopRoutine() {
 			select {
 			case tracker._stopChan <- true:
 				return
-			case c = <-tracker._expectChan:
-				tracker._waiting += 1
-			case c = <-tracker._doneChan:
+			case <-tracker._expectChan:
+				tracker._waiting++
+			case <-tracker._doneChan:
 				panic("Tracker got an unexpected done call.")
 			}
 		}
@@ -568,13 +568,13 @@ func newSuiteRunner(suite interface{}, runConf *RunConf) *suiteRunner {
 
 	var filterRegexp *regexp.Regexp
 	if conf.Filter != "" {
-		if regexp, err := regexp.Compile(conf.Filter); err != nil {
+		regexp, err := regexp.Compile(conf.Filter)
+		if err != nil {
 			msg := "Bad filter expression: " + err.Error()
 			runner.tracker.result.RunError = errors.New(msg)
 			return runner
-		} else {
-			filterRegexp = regexp
 		}
+		filterRegexp = regexp
 	}
 
 	for i := 0; i != suiteNumMethods; i++ {

--- a/vendor/github.com/go-check/check/checkers.go
+++ b/vendor/github.com/go-check/check/checkers.go
@@ -212,7 +212,7 @@ type hasLenChecker struct {
 
 // The HasLen checker verifies that the obtained value has the
 // provided length. In many cases this is superior to using Equals
-// in conjuction with the len function because in case the check
+// in conjunction with the len function because in case the check
 // fails the value itself will be printed, instead of its length,
 // providing more details for figuring the problem.
 //


### PR DESCRIPTION
This pulls in https://github.com/containers/image/pull/165 , just to make a testable branch of skopeo with these changes, defining a required format for `docker-daemon:` references:

Allow either a `!NameOnly` named reference, or a `sha256:`hex digest.  Both forms can be used for an `ImageSource`; `ImageDestination` accepts only a name`:`tag value.
    
Because the `sha256:`hex reference values make it impossible to create a reasonable policy hierarchy, we only support a trivial `policy.json` namespace with a single per-transport policy.

@baude , are there any automated tests which could be run to verify that this does not break `atomic`’s use of `docker-daemon:`?