### PR TITLE
use user/pass flags

### DIFF
--- a/cmd/skopeo/copy.go
+++ b/cmd/skopeo/copy.go
@@ -7,8 +7,24 @@ import (
 
 	"github.com/containers/image/copy"
 	"github.com/containers/image/transports"
+	"github.com/containers/image/types"
 	"github.com/urfave/cli"
 )
+
+// contextsFromGlobalOptions returns source and destionation types.SystemContext depending on c.
+func contextsFromGlobalOptions(c *cli.Context) (*types.SystemContext, *types.SystemContext, error) {
+	sourceCtx, err := contextFromGlobalOptions(c, "src-creds")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	destinationCtx, err := contextFromGlobalOptions(c, "dest-creds")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return sourceCtx, destinationCtx, nil
+}
 
 func copyHandler(context *cli.Context) error {
 	if len(context.Args()) != 2 {
@@ -32,10 +48,17 @@ func copyHandler(context *cli.Context) error {
 	signBy := context.String("sign-by")
 	removeSignatures := context.Bool("remove-signatures")
 
-	return copy.Image(contextFromGlobalOptions(context), policyContext, destRef, srcRef, &copy.Options{
+	sourceCtx, destinationCtx, err := contextsFromGlobalOptions(context)
+	if err != nil {
+		return err
+	}
+
+	return copy.Image(policyContext, destRef, srcRef, &copy.Options{
 		RemoveSignatures: removeSignatures,
 		SignBy:           signBy,
 		ReportWriter:     os.Stdout,
+		SourceCtx:        sourceCtx,
+		DestinationCtx:   destinationCtx,
 	})
 }
 
@@ -53,6 +76,16 @@ var copyCmd = cli.Command{
 		cli.StringFlag{
 			Name:  "sign-by",
 			Usage: "Sign the image using a GPG key with the specified `FINGERPRINT`",
+		},
+		cli.StringFlag{
+			Name:  "src-creds, screds",
+			Value: "",
+			Usage: "Use `USERNAME[:PASSWORD]` for accessing the source registry",
+		},
+		cli.StringFlag{
+			Name:  "dest-creds, dcreds",
+			Value: "",
+			Usage: "Use `USERNAME[:PASSWORD]` for accessing the destination registry",
 		},
 	},
 }

--- a/cmd/skopeo/delete.go
+++ b/cmd/skopeo/delete.go
@@ -18,7 +18,11 @@ func deleteHandler(context *cli.Context) error {
 		return fmt.Errorf("Invalid source name %s: %v", context.Args()[0], err)
 	}
 
-	if err := ref.DeleteImage(contextFromGlobalOptions(context)); err != nil {
+	ctx, err := contextFromGlobalOptions(context, "creds")
+	if err != nil {
+		return err
+	}
+	if err := ref.DeleteImage(ctx); err != nil {
 		return err
 	}
 	return nil
@@ -29,4 +33,11 @@ var deleteCmd = cli.Command{
 	Usage:     "Delete image IMAGE-NAME",
 	ArgsUsage: "IMAGE-NAME",
 	Action:    deleteHandler,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "creds",
+			Value: "",
+			Usage: "Use `USERNAME[:PASSWORD]` for accessing the registry",
+		},
+	},
 }

--- a/cmd/skopeo/inspect.go
+++ b/cmd/skopeo/inspect.go
@@ -34,6 +34,11 @@ var inspectCmd = cli.Command{
 			Name:  "raw",
 			Usage: "output raw manifest",
 		},
+		cli.StringFlag{
+			Name:  "creds",
+			Value: "",
+			Usage: "Use `USERNAME[:PASSWORD]` for accessing the registry",
+		},
 	},
 	Action: func(c *cli.Context) error {
 		img, err := parseImage(c)

--- a/cmd/skopeo/main.go
+++ b/cmd/skopeo/main.go
@@ -25,22 +25,10 @@ func createApp() *cli.App {
 		app.Version = version.Version
 	}
 	app.Usage = "Various operations with container images and container image registries"
-	// TODO(runcom)
-	//app.EnableBashCompletion = true
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{
 			Name:  "debug",
 			Usage: "enable debug output",
-		},
-		cli.StringFlag{
-			Name:  "username",
-			Value: "",
-			Usage: "use `USERNAME` for accessing the registry",
-		},
-		cli.StringFlag{
-			Name:  "password",
-			Value: "",
-			Usage: "use `PASSWORD` for accessing the registry",
 		},
 		cli.StringFlag{
 			Name:  "cert-path",

--- a/docs/skopeo.1.md
+++ b/docs/skopeo.1.md
@@ -37,10 +37,6 @@ Most commands refer to container images, using a _transport_`:`_details_ format.
 
   **--debug** enable debug output
 
-  **--username** _username_ for accessing  the registry
-
-  **--password** _password_ for accessing the registry
-
   **--cert-path** _path_ Use certificates at _path_ (cert.pem, key.pem) to connect to the registry
 
   **--policy** _path-to-policy_ Path to a policy.json file to use for verifying signatures and deciding whether an image is trusted, overriding the default trust policy file.
@@ -70,6 +66,10 @@ Uses the system's trust policy to validate images, rejects images not trusted by
 
   **--sign-by=**_key-id_ add a signature using that key ID for an image name corresponding to _destination-image_
 
+  **--src-creds** _username[:password]_ for accessing the source registry
+
+  **--dest-creds** _username[:password]_ for accessing the destination registry
+
 Existing signatures, if any, are preserved as well.
 
 ## skopeo delete
@@ -81,6 +81,8 @@ Mark _image-name_ for deletion.  To release the allocated disk space, you need t
 $ docker exec -it registry bin/registry garbage-collect /etc/docker/registry/config.yml
 ```
 
+  **--creds** _username[:password]_ for accessing the registry
+
 Additionally, the registry must allow deletions by setting `REGISTRY_STORAGE_DELETE_ENABLED=true` for the registry daemon.
 
 ## skopeo inspect
@@ -91,6 +93,8 @@ Return low-level information about _image-name_ in a registry
   **--raw** output raw manifest, default is to format in JSON
 
   _image-name_ name of image to retrieve information about
+
+  **--creds** _username[:password]_ for accessing the registry
 
 ## skopeo layers
 **skopeo layers** _image-name_

--- a/integration/check_test.go
+++ b/integration/check_test.go
@@ -76,17 +76,13 @@ func (s *SkopeoSuite) TestVersion(c *check.C) {
 }
 
 func (s *SkopeoSuite) TestCanAuthToPrivateRegistryV2WithoutDockerCfg(c *check.C) {
-	// TODO(runcom)
-	c.Skip("we need to restore --username --password flags!")
-	wanted := ".*unauthorized: authentication required.*"
-	assertSkopeoFails(c, wanted, "--docker-cfg=''", "--username="+s.regV2WithAuth.username, "--password="+s.regV2WithAuth.password, "inspect", fmt.Sprintf("docker://%s/busybox:latest", s.regV2WithAuth.url))
+	wanted := ".*manifest unknown: manifest unknown.*"
+	assertSkopeoFails(c, wanted, "--tls-verify=false", "inspect", "--creds="+s.regV2WithAuth.username+":"+s.regV2WithAuth.password, fmt.Sprintf("docker://%s/busybox:latest", s.regV2WithAuth.url))
 }
 
 func (s *SkopeoSuite) TestNeedAuthToPrivateRegistryV2WithoutDockerCfg(c *check.C) {
-	// TODO(runcom): mock the empty docker-cfg by removing it in the test itself (?)
-	c.Skip("mock empty docker config")
 	wanted := ".*unauthorized: authentication required.*"
-	assertSkopeoFails(c, wanted, "--docker-cfg=''", "inspect", fmt.Sprintf("docker://%s/busybox:latest", s.regV2WithAuth.url))
+	assertSkopeoFails(c, wanted, "--tls-verify=false", "inspect", fmt.Sprintf("docker://%s/busybox:latest", s.regV2WithAuth.url))
 }
 
 // TODO(runcom): as soon as we can push to registries ensure you can inspect here

--- a/integration/copy_test.go
+++ b/integration/copy_test.go
@@ -397,3 +397,20 @@ func (s *CopySuite) TestCopyDockerSigstore(c *check.C) {
 	splitSigstoreReadServerHandler = http.FileServer(http.Dir(splitSigstoreStaging))
 	assertSkopeoSucceeds(c, "", "--tls-verify=false", "--policy", policy, "--registries.d", registriesDir, "copy", ourRegistry+"public/busybox", dirDest)
 }
+
+func (s *SkopeoSuite) TestCopySrcWithAuth(c *check.C) {
+	assertSkopeoSucceeds(c, "", "--tls-verify=false", "copy", "--dest-creds=testuser:testpassword", "docker://busybox", fmt.Sprintf("docker://%s/busybox:latest", s.regV2WithAuth.url))
+	dir1, err := ioutil.TempDir("", "copy-1")
+	c.Assert(err, check.IsNil)
+	defer os.RemoveAll(dir1)
+	assertSkopeoSucceeds(c, "", "--tls-verify=false", "copy", "--src-creds=testuser:testpassword", fmt.Sprintf("docker://%s/busybox:latest", s.regV2WithAuth.url), "dir:"+dir1)
+}
+
+func (s *SkopeoSuite) TestCopyDestWithAuth(c *check.C) {
+	assertSkopeoSucceeds(c, "", "--tls-verify=false", "copy", "--dest-creds=testuser:testpassword", "docker://busybox", fmt.Sprintf("docker://%s/busybox:latest", s.regV2WithAuth.url))
+}
+
+func (s *SkopeoSuite) TestCopySrcAndDestWithAuth(c *check.C) {
+	assertSkopeoSucceeds(c, "", "--tls-verify=false", "copy", "--dest-creds=testuser:testpassword", "docker://busybox", fmt.Sprintf("docker://%s/busybox:latest", s.regV2WithAuth.url))
+	assertSkopeoSucceeds(c, "", "--tls-verify=false", "copy", "--src-creds=testuser:testpassword", "--dest-creds=testuser:testpassword", fmt.Sprintf("docker://%s/busybox:latest", s.regV2WithAuth.url), fmt.Sprintf("docker://%s/test:auth", s.regV2WithAuth.url))
+}


### PR DESCRIPTION
We already use global flags for docker specific stuff. This patch enables `--username` and `--password` to be passed down to `containers/image` to setup docker's registries auth.

Fixes #253 

@mtrmac @cyphar PTAL

Signed-off-by: Antonio Murdaca <runcom@redhat.com>