### PR TITLE
revendor github.com/docker/go-connections

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -16,7 +16,7 @@ clone git github.com/pmezard/go-difflib master
 # docker deps from https://github.com/docker/docker/blob/v1.11.2/hack/vendor.sh
 clone git github.com/docker/docker v1.12.1
 clone git github.com/docker/engine-api 4eca04ae18f4f93f40196a17b9aa6e11262a7269
-clone git github.com/docker/go-connections v0.2.0
+clone git github.com/docker/go-connections 4ccf312bf1d35e5dbda654e57a9be4c3f3cd0366
 clone git github.com/vbatts/tar-split v0.9.11
 clone git github.com/gorilla/context 14f550f51a
 clone git github.com/gorilla/mux e444e69cbd

--- a/vendor/github.com/docker/go-connections/nat/parse.go
+++ b/vendor/github.com/docker/go-connections/nat/parse.go
@@ -8,6 +8,7 @@ import (
 
 // PartParser parses and validates the specified string (data) using the specified template
 // e.g. ip:public:private -> 192.168.0.1:80:8000
+// DEPRECATED: do not use, this function may be removed in a future version
 func PartParser(template, data string) (map[string]string, error) {
 	// ip:public:private
 	var (

--- a/vendor/github.com/docker/go-connections/sockets/inmem_socket.go
+++ b/vendor/github.com/docker/go-connections/sockets/inmem_socket.go
@@ -79,11 +79,3 @@ func (a dummyAddr) Network() string {
 func (a dummyAddr) String() string {
 	return string(a)
 }
-
-// timeoutError is used when there is a timeout with a connection
-// this implements the net.Error interface
-type timeoutError struct{}
-
-func (e *timeoutError) Error() string   { return "i/o timeout" }
-func (e *timeoutError) Timeout() bool   { return true }
-func (e *timeoutError) Temporary() bool { return true }

--- a/vendor/github.com/docker/go-connections/sockets/sockets_unix.go
+++ b/vendor/github.com/docker/go-connections/sockets/sockets_unix.go
@@ -3,10 +3,30 @@
 package sockets
 
 import (
+	"fmt"
 	"net"
+	"net/http"
 	"syscall"
 	"time"
 )
+
+const maxUnixSocketPathSize = len(syscall.RawSockaddrUnix{}.Path)
+
+func configureUnixTransport(tr *http.Transport, proto, addr string) error {
+	if len(addr) > maxUnixSocketPathSize {
+		return fmt.Errorf("Unix socket path %q is too long", addr)
+	}
+	// No need for compression in local communications.
+	tr.DisableCompression = true
+	tr.Dial = func(_, _ string) (net.Conn, error) {
+		return net.DialTimeout(proto, addr, defaultTimeout)
+	}
+	return nil
+}
+
+func configureNpipeTransport(tr *http.Transport, proto, addr string) error {
+	return ErrProtocolNotAvailable
+}
 
 // DialPipe connects to a Windows named pipe.
 // This is not supported on other OSes.

--- a/vendor/github.com/docker/go-connections/sockets/sockets_windows.go
+++ b/vendor/github.com/docker/go-connections/sockets/sockets_windows.go
@@ -2,10 +2,24 @@ package sockets
 
 import (
 	"net"
+	"net/http"
 	"time"
 
 	"github.com/Microsoft/go-winio"
 )
+
+func configureUnixTransport(tr *http.Transport, proto, addr string) error {
+	return ErrProtocolNotAvailable
+}
+
+func configureNpipeTransport(tr *http.Transport, proto, addr string) error {
+	// No need for compression in local communications.
+	tr.DisableCompression = true
+	tr.Dial = func(_, _ string) (net.Conn, error) {
+		return DialPipe(addr, defaultTimeout)
+	}
+	return nil
+}
 
 // DialPipe connects to a Windows named pipe.
 func DialPipe(addr string, timeout time.Duration) (net.Conn, error) {

--- a/vendor/github.com/docker/go-connections/sockets/tcp_socket.go
+++ b/vendor/github.com/docker/go-connections/sockets/tcp_socket.go
@@ -7,7 +7,7 @@ import (
 )
 
 // NewTCPSocket creates a TCP socket listener with the specified address and
-// and the specified tls configuration. If TLSConfig is set, will encapsulate the
+// the specified tls configuration. If TLSConfig is set, will encapsulate the
 // TCP listener inside a TLS one.
 func NewTCPSocket(addr string, tlsConfig *tls.Config) (net.Listener, error) {
 	l, err := net.Listen("tcp", addr)

--- a/vendor/github.com/docker/go-connections/tlsconfig/certpool_go17.go
+++ b/vendor/github.com/docker/go-connections/tlsconfig/certpool_go17.go
@@ -1,0 +1,21 @@
+// +build go1.7
+
+package tlsconfig
+
+import (
+	"crypto/x509"
+	"runtime"
+
+	"github.com/Sirupsen/logrus"
+)
+
+// SystemCertPool returns a copy of the system cert pool,
+// returns an error if failed to load or empty pool on windows.
+func SystemCertPool() (*x509.CertPool, error) {
+	certpool, err := x509.SystemCertPool()
+	if err != nil && runtime.GOOS == "windows" {
+		logrus.Warnf("Unable to use system certificate pool: %v", err)
+		return x509.NewCertPool(), nil
+	}
+	return certpool, err
+}

--- a/vendor/github.com/docker/go-connections/tlsconfig/certpool_other.go
+++ b/vendor/github.com/docker/go-connections/tlsconfig/certpool_other.go
@@ -1,0 +1,16 @@
+// +build !go1.7
+
+package tlsconfig
+
+import (
+	"crypto/x509"
+
+	"github.com/Sirupsen/logrus"
+)
+
+// SystemCertPool returns an new empty cert pool,
+// accessing system cert pool is supported in go 1.7
+func SystemCertPool() (*x509.CertPool, error) {
+	logrus.Warn("Unable to use system certificate pool: requires building with go 1.7 or later")
+	return x509.NewCertPool(), nil
+}

--- a/vendor/github.com/docker/go-connections/tlsconfig/config.go
+++ b/vendor/github.com/docker/go-connections/tlsconfig/config.go
@@ -46,44 +46,46 @@ var acceptedCBCCiphers = []uint16{
 // known weak algorithms removed.
 var DefaultServerAcceptedCiphers = append(clientCipherSuites, acceptedCBCCiphers...)
 
-// ServerDefault is a secure-enough TLS configuration for the server TLS configuration.
-var ServerDefault = tls.Config{
-	// Avoid fallback to SSL protocols < TLS1.0
-	MinVersion:               tls.VersionTLS10,
-	PreferServerCipherSuites: true,
-	CipherSuites:             DefaultServerAcceptedCiphers,
+// ServerDefault returns a secure-enough TLS configuration for the server TLS configuration.
+func ServerDefault() *tls.Config {
+	return &tls.Config{
+		// Avoid fallback to SSL protocols < TLS1.0
+		MinVersion:               tls.VersionTLS10,
+		PreferServerCipherSuites: true,
+		CipherSuites:             DefaultServerAcceptedCiphers,
+	}
 }
 
-// ClientDefault is a secure-enough TLS configuration for the client TLS configuration.
-var ClientDefault = tls.Config{
-	// Prefer TLS1.2 as the client minimum
-	MinVersion:   tls.VersionTLS12,
-	CipherSuites: clientCipherSuites,
+// ClientDefault returns a secure-enough TLS configuration for the client TLS configuration.
+func ClientDefault() *tls.Config {
+	return &tls.Config{
+		// Prefer TLS1.2 as the client minimum
+		MinVersion:   tls.VersionTLS12,
+		CipherSuites: clientCipherSuites,
+	}
 }
 
 // certPool returns an X.509 certificate pool from `caFile`, the certificate file.
 func certPool(caFile string) (*x509.CertPool, error) {
 	// If we should verify the server, we need to load a trusted ca
-	certPool := x509.NewCertPool()
+	certPool, err := SystemCertPool()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read system certificates: %v", err)
+	}
 	pem, err := ioutil.ReadFile(caFile)
 	if err != nil {
-		return nil, fmt.Errorf("Could not read CA certificate %q: %v", caFile, err)
+		return nil, fmt.Errorf("could not read CA certificate %q: %v", caFile, err)
 	}
 	if !certPool.AppendCertsFromPEM(pem) {
 		return nil, fmt.Errorf("failed to append certificates from PEM file: %q", caFile)
 	}
-	s := certPool.Subjects()
-	subjects := make([]string, len(s))
-	for i, subject := range s {
-		subjects[i] = string(subject)
-	}
-	logrus.Debugf("Trusting certs with subjects: %v", subjects)
+	logrus.Debugf("Trusting %d certs", len(certPool.Subjects()))
 	return certPool, nil
 }
 
 // Client returns a TLS configuration meant to be used by a client.
 func Client(options Options) (*tls.Config, error) {
-	tlsConfig := ClientDefault
+	tlsConfig := ClientDefault()
 	tlsConfig.InsecureSkipVerify = options.InsecureSkipVerify
 	if !options.InsecureSkipVerify && options.CAFile != "" {
 		CAs, err := certPool(options.CAFile)
@@ -101,12 +103,12 @@ func Client(options Options) (*tls.Config, error) {
 		tlsConfig.Certificates = []tls.Certificate{tlsCert}
 	}
 
-	return &tlsConfig, nil
+	return tlsConfig, nil
 }
 
 // Server returns a TLS configuration meant to be used by a server.
 func Server(options Options) (*tls.Config, error) {
-	tlsConfig := ServerDefault
+	tlsConfig := ServerDefault()
 	tlsConfig.ClientAuth = options.ClientAuth
 	tlsCert, err := tls.LoadX509KeyPair(options.CertFile, options.KeyFile)
 	if err != nil {
@@ -123,5 +125,5 @@ func Server(options Options) (*tls.Config, error) {
 		}
 		tlsConfig.ClientCAs = CAs
 	}
-	return &tlsConfig, nil
+	return tlsConfig, nil
 }


### PR DESCRIPTION
Update the version of github.com/docker/go-connections that we vendor to the current-as-of-this-writing version, so that we can build against the current version of `containers/image`, which needs a version of
`github.com/docker/go-connections/tlsconfig` which provides a `SystemCertPool()` function.