### PR TITLE
Bump v0.1.17 and again to v0.1.18-dev

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.1.17"
+const Version = "0.1.18-dev"

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.1.17-dev"
+const Version = "0.1.17"


### PR DESCRIPTION
I'll tag `v0.1.17` the following commit: https://github.com/runcom/skopeo-1/commit/b3b4e2b8f8cebba9a9fe50e8e9c6cf4fe600c448