### PR TITLE
Remove an obsolete FIXME

### DIFF
--- a/cmd/skopeo/signing_test.go
+++ b/cmd/skopeo/signing_test.go
@@ -55,7 +55,7 @@ func TestStandaloneSign(t *testing.T) {
 		manifestPath, "" /* empty reference */, fixturesTestKeyFingerprint)
 	assertTestFailed(t, out, err, "empty signature content")
 
-	// Unknown key. (FIXME? The error is 'Error creating signature: End of file")
+	// Unknown key.
 	out, err = runSkopeo("standalone-sign", "-o", "/dev/null",
 		manifestPath, dockerReference, "UNKNOWN GPG FINGERPRINT")
 	assert.Error(t, err)


### PR DESCRIPTION
With https://github.com/containers/image/pull/183 , this no longer applies.