### PR TITLE
Makefile: use go-md2man in the skopeobuildimage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ CONTAINERSSYSCONFIGDIR=${DESTDIR}/etc/containers
 REGISTRIESDDIR=${CONTAINERSSYSCONFIGDIR}/registries.d
 SIGSTOREDIR=${DESTDIR}/var/lib/atomic/sigstore
 BASHINSTALLDIR=${PREFIX}/share/bash-completion/completions
-GO_MD2MAN ?= /usr/bin/go-md2man
 
 ifeq ($(DEBUG), 1)
   override GOGCFLAGS += -N -l
@@ -66,7 +65,7 @@ build-container:
 	docker build ${DOCKER_BUILD_ARGS} -t "$(DOCKER_IMAGE)" .
 
 docs/%.1: docs/%.1.md
-	$(GO_MD2MAN) -in $< -out $@.tmp && touch $@.tmp && mv $@.tmp $@
+	docker run -i --rm skopeobuildimage go-md2man -in /dev/stdin -out /dev/stdout < $< > $@.tmp && touch $@.tmp && mv $@.tmp $@
 
 .PHONY: docs
 docs: $(MANPAGES_MD:%.md=%)

--- a/README.md
+++ b/README.md
@@ -103,10 +103,6 @@ you'll get an error. You can fix this by either logging in (via `docker login`) 
 
 Building
 -
-To build the manual you will need go-md2man.
-```sh
-$ sudo apt-get install go-md2man
-```
 To build the `skopeo` binary you need at least Go 1.5 because it uses the latest `GO15VENDOREXPERIMENT` flag. Also, make sure to clone the repository in your `GOPATH` - otherwise compilation fails.  
 ```sh
 $ git clone https://github.com/projectatomic/skopeo $GOPATH/src/github.com/projectatomic/skopeo


### PR DESCRIPTION
Previously, the doc cannot be built if go-md2man is not installed on the host.

So I suggest using go-md2man installed in the skopeobuildimage (https://github.com/projectatomic/skopeo/pull/243/files#diff-d92c0cc6cc3b84dda3c92547bcf56981R3)

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>