### PR TITLE
Makefile: /usr/bin/go-md2man -> go-md2man

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ CONTAINERSSYSCONFIGDIR=${DESTDIR}/etc/containers
 REGISTRIESDDIR=${CONTAINERSSYSCONFIGDIR}/registries.d
 SIGSTOREDIR=${DESTDIR}/var/lib/atomic/sigstore
 BASHINSTALLDIR=${PREFIX}/share/bash-completion/completions
-GO_MD2MAN ?= /usr/bin/go-md2man
+GO_MD2MAN ?= go-md2man
 
 ifeq ($(DEBUG), 1)
   override GOGCFLAGS += -N -l


### PR DESCRIPTION
When user installed go-md2man via `go get`, it is unlikely to be installed as `/usr/bin/go-md2man`.

So I suggest changing `/usr/bin/go-md2man` to just `go-md2man`.


Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>