### PR TITLE
Vendor mtrmac/image:change-sigstore-layout

### DIFF
--- a/vendor/github.com/containers/image/docker/lookaside.go
+++ b/vendor/github.com/containers/image/docker/lookaside.go
@@ -9,12 +9,12 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/Sirupsen/logrus"
+	"github.com/containers/image/docker/reference"
+	"github.com/containers/image/types"
 	"github.com/ghodss/yaml"
 	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
-
-	"github.com/Sirupsen/logrus"
-	"github.com/containers/image/types"
 )
 
 // systemRegistriesDirPath is the path to registries.d, used for locating lookaside Docker signature storage.
@@ -64,8 +64,8 @@ func configuredSignatureStorageBase(ctx *types.SystemContext, ref dockerReferenc
 		return nil, errors.Wrapf(err, "Invalid signature storage URL %s", topLevel)
 	}
 	// FIXME? Restrict to explicitly supported schemes?
-	repo := ref.ref.Name()        // Note that this is without a tag or digest.
-	if path.Clean(repo) != repo { // Coverage: This should not be reachable because /./ and /../ components are not valid in docker references
+	repo := reference.Path(ref.ref) // Note that this is without a tag or digest.
+	if path.Clean(repo) != repo {   // Coverage: This should not be reachable because /./ and /../ components are not valid in docker references
 		return nil, errors.Errorf("Unexpected path elements in Docker reference %s for signature storage", ref.ref.String())
 	}
 	url.Path = url.Path + "/" + repo
@@ -195,6 +195,6 @@ func signatureStorageURL(base signatureStorageBase, manifestDigest digest.Digest
 		return nil
 	}
 	url := *base
-	url.Path = fmt.Sprintf("%s@%s/signature-%d", url.Path, manifestDigest.String(), index+1)
+	url.Path = fmt.Sprintf("%s@%s=%s/signature-%d", url.Path, manifestDigest.Algorithm(), manifestDigest.Hex(), index+1)
 	return &url
 }

--- a/vendor/k8s.io/client-go/README.md
+++ b/vendor/k8s.io/client-go/README.md
@@ -77,20 +77,21 @@ We will backport bugfixes--but not new features--into older versions of
 
 #### Compatibility matrix
 
-|                | Kubernetes 1.3 | Kubernetes 1.4 | Kubernetes 1.5 | Kubernetes 1.6 (not released yet) |
-|----------------|----------------|----------------|----------------|----------------|
-| client-go 1.4  | +              | ✓              | -              | -              |
-| client-go 1.5  | +              | +              | -              | -              |
-| client-go 2.0  | +              | +              | ✓              | -              |
-| client-go HEAD | +              | +              | +              | ✓              |
+|                     | Kubernetes 1.3 | Kubernetes 1.4 | Kubernetes 1.5 | Kubernetes 1.6 |
+|---------------------|----------------|----------------|----------------|----------------|
+| client-go 1.4       | +              | ✓              | -              | -              |
+| client-go 1.5       | +              | +              | -              | -              |
+| client-go 2.0       | +              | +              | ✓              | -              |
+| client-go 3.0 beta  | +              | +              | +              | ✓              |
+| client-go HEAD      | +              | +              | +              | +              |
 
 Key:
 
-* ✓ Exactly the same features / API objects in both client-go and the Kubernetes
+* `✓` Exactly the same features / API objects in both client-go and the Kubernetes
   version.
-* + client-go has features or api objects that may not be present in the
+* `+` client-go has features or api objects that may not be present in the
   Kubernetes cluster, but everything they have in common will work.
-* - The Kubernetes cluster has features the client-go library can't use
+* `-` The Kubernetes cluster has features the client-go library can't use
   (additional API objects, etc).
 
 See the [CHANGELOG](./CHANGELOG.md) for a detailed description of changes
@@ -101,13 +102,14 @@ between client-go versions.
 | client-go 1.4  | Kubernetes main repo, 1.4 branch     | = -                           |
 | client-go 1.5  | Kubernetes main repo, 1.5 branch     | = -                           |
 | client-go 2.0  | Kubernetes main repo, 1.5 branch     | ✓                             |
+| client-go 3.0  | Kubernetes main repo, 1.6 branch     | ✓                             |
 | client-go HEAD | Kubernetes main repo, master branch  | ✓                             |
 
 Key:
 
-* ✓ Changes in main Kubernetes repo are actively published to client-go by a bot
-* = Maintenance is manual, only severe security bugs will be patched.
-* - Deprecated; please upgrade.
+* `✓` Changes in main Kubernetes repo are actively published to client-go by a bot
+* `=` Maintenance is manual, only severe security bugs will be patched.
+* `-` Deprecated; please upgrade.
 
 #### Deprecation policy
 


### PR DESCRIPTION
This demonstrates https://github.com/containers/image/pull/247 .  There is a `TestCopyDockerSigstore` which tests that the write staging / read HTTP paths for a sigstore are interoperable, but it does not prescribe a specific layout, so it does not need updating.