### PR TITLE
Update OpenShift in integration tests to get the docker/distribution API extensions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN set -x \
 RUN set -x \
 	&& yum install -y which git tar wget hostname util-linux bsdtar socat ethtool device-mapper iptables tree findutils nmap-ncat e2fsprogs xfsprogs lsof docker iproute \
 	&& export GOPATH=$(mktemp -d) \
-	&& git clone -b v1.3.0-alpha.3 git://github.com/openshift/origin "$GOPATH/src/github.com/openshift/origin" \
+	&& git clone -b v1.5.0-alpha.3 git://github.com/openshift/origin "$GOPATH/src/github.com/openshift/origin" \
 	&& (cd "$GOPATH/src/github.com/openshift/origin" && make clean build && make all WHAT=cmd/dockerregistry) \
 	&& cp -a "$GOPATH/src/github.com/openshift/origin/_output/local/bin/linux"/*/* /usr/local/bin \
 	&& cp "$GOPATH/src/github.com/openshift/origin/images/dockerregistry/config.yml" /atomic-registry-config.yml \

--- a/integration/utils.go
+++ b/integration/utils.go
@@ -74,9 +74,15 @@ func assertSkopeoFails(c *check.C, regexp string, args ...string) {
 // runCommandWithInput runs a command as if exec.Command(), sending it the input to stdin,
 // and verifies that the exit status is 0, or terminates c on failure.
 func runCommandWithInput(c *check.C, input string, name string, args ...string) {
-	c.Logf("Running %s %s", name, strings.Join(args, " "))
 	cmd := exec.Command(name, args...)
-	consumeAndLogOutputs(c, name+" "+strings.Join(args, " "), cmd)
+	runExecCmdWithInput(c, cmd, input)
+}
+
+// runExecCmdWithInput runs an exec.Cmd, sending it the input to stdin,
+// and verifies that the exit status is 0, or terminates c on failure.
+func runExecCmdWithInput(c *check.C, cmd *exec.Cmd, input string) {
+	c.Logf("Running %s %s", cmd.Path, strings.Join(cmd.Args, " "))
+	consumeAndLogOutputs(c, cmd.Path+" "+strings.Join(cmd.Args, " "), cmd)
 	stdin, err := cmd.StdinPipe()
 	c.Assert(err, check.IsNil)
 	err = cmd.Start()


### PR DESCRIPTION
This updates OpenShift from 1.3.0-alpha.3 to 1.5.0-alpha.3.

More detailed description is in the individual commit messages.