### PR TITLE
Fix wrong naming of cert-dir argument in inspect command

### DIFF
--- a/cmd/skopeo/inspect.go
+++ b/cmd/skopeo/inspect.go
@@ -32,7 +32,7 @@ var inspectCmd = cli.Command{
 	ArgsUsage: "IMAGE-NAME",
 	Flags: []cli.Flag{
 		cli.StringFlag{
-			Name:  "cert-path",
+			Name:  "cert-dir",
 			Value: "",
 			Usage: "use certificates at `PATH` (*.crt, *.cert, *.key) to connect to the registry",
 		},

--- a/completions/bash/skopeo
+++ b/completions/bash/skopeo
@@ -23,10 +23,10 @@ _skopeo_copy() {
      local options_with_args="
 	--sign-by
 	--src-creds --screds
-	--src-cert-path
+	--src-cert-dir
 	--src-tls-verify
 	--dest-creds --dcreds
-	--dest-cert-path
+	--dest-cert-dir
 	--dest-tls-verify
      "
      local boolean_options="
@@ -38,7 +38,7 @@ _skopeo_copy() {
 _skopeo_inspect() {
      local options_with_args="
 	--creds
-	--cert-path
+	--cert-dir
      "
      local boolean_options="
 	--raw
@@ -75,7 +75,7 @@ _skopeo_manifest_digest() {
 _skopeo_delete() {
      local options_with_args="
 	   --creds
-	   --cert-path
+	   --cert-dir
      "
      local boolean_options="
 	   --tls-verify
@@ -86,7 +86,7 @@ _skopeo_delete() {
 _skopeo_layers() {
      local options_with_args="
 	   --creds
-	   --cert-path
+	   --cert-dir
      "
      local boolean_options="
 	   --tls-verify

--- a/integration/check_test.go
+++ b/integration/check_test.go
@@ -85,6 +85,13 @@ func (s *SkopeoSuite) TestNeedAuthToPrivateRegistryV2WithoutDockerCfg(c *check.C
 	assertSkopeoFails(c, wanted, "--tls-verify=false", "inspect", fmt.Sprintf("docker://%s/busybox:latest", s.regV2WithAuth.url))
 }
 
+func (s *SkopeoSuite) TestCertDirInsteadOfCertPath(c *check.C) {
+	wanted := ".*flag provided but not defined: -cert-path.*"
+	assertSkopeoFails(c, wanted, "--tls-verify=false", "inspect", fmt.Sprintf("docker://%s/busybox:latest", s.regV2WithAuth.url), "--cert-path=/")
+	wanted = ".*unauthorized: authentication required.*"
+	assertSkopeoFails(c, wanted, "--tls-verify=false", "inspect", fmt.Sprintf("docker://%s/busybox:latest", s.regV2WithAuth.url), "--cert-dir=/etc/docker/certs.d/")
+}
+
 // TODO(runcom): as soon as we can push to registries ensure you can inspect here
 // not just get image not found :)
 func (s *SkopeoSuite) TestNoNeedAuthToPrivateRegistryV2ImageNotFound(c *check.C) {


### PR DESCRIPTION
A wrong name of this parameter prevents it from being used for the context (and at all). This is also different than the docs.