### PR TITLE
Insecure policy flag redux

### DIFF
--- a/cmd/skopeo/main.go
+++ b/cmd/skopeo/main.go
@@ -41,6 +41,10 @@ func createApp() *cli.App {
 			Value: "",
 			Usage: "Path to a trust policy file",
 		},
+		cli.BoolFlag{
+			Name:  "insecure-policy",
+			Usage: "run the tool without any policy check",
+		},
 		cli.StringFlag{
 			Name:  "registries.d",
 			Value: "",
@@ -84,7 +88,9 @@ func getPolicyContext(c *cli.Context) (*signature.PolicyContext, error) {
 	policyPath := c.GlobalString("policy")
 	var policy *signature.Policy // This could be cached across calls, if we had an application context.
 	var err error
-	if policyPath == "" {
+	if c.GlobalBool("insecure-policy") {
+		policy = &signature.Policy{Default: []signature.PolicyRequirement{signature.NewPRInsecureAcceptAnything()}}
+	} else if policyPath == "" {
 		policy, err = signature.DefaultPolicy(nil)
 	} else {
 		policy, err = signature.NewPolicyFromFile(policyPath)

--- a/completions/bash/skopeo
+++ b/completions/bash/skopeo
@@ -100,6 +100,7 @@ _skopeo_skopeo() {
 	   --registries.d
      "
      local boolean_options="
+	   --insecure-policy
 	   --debug
 	   --version -v
 	   --help -h

--- a/docs/skopeo.1.md
+++ b/docs/skopeo.1.md
@@ -39,6 +39,8 @@ Most commands refer to container images, using a _transport_`:`_details_ format.
 
   **--policy** _path-to-policy_ Path to a policy.json file to use for verifying signatures and deciding whether an image is trusted, overriding the default trust policy file.
 
+  **--insecure-policy** Adopt an insecure, permissive policy that allows anything. This obviates the need for a policy file.
+
   **--registries.d** _dir_ use registry configuration files in _dir_ (e.g. for docker signature storage), overriding the default path.
 
   **--help**|**-h** Show help


### PR DESCRIPTION
This PR is merely a rebase of #203, whose submitter needed to rebase their PR.
I resolved a trivial merge conflict to rebase, and the flag works as advertised.

I'm assuming that the previous agreement on the flag name,  `--insecure-policy`, is still valid, and I updated the bash completion and man page accordingly. Let me know if there's anywhere else :)

Original submission follows:

> This patch adds a new flag --insecure-policy.
> Closes #181, we can now directly use the tool with the
> above mentioned flag wihout using a policy file
> 
> Signed-off-by: Kushal Das <mail@kushaldas.in>