### PR TITLE
Add a commented-out CopySuite.TestRunShell

### DIFF
--- a/integration/openshift_shell_test.go
+++ b/integration/openshift_shell_test.go
@@ -1,0 +1,40 @@
+// +build openshift_shell
+
+package main
+
+import (
+	"os"
+	"os/exec"
+
+	"github.com/go-check/check"
+)
+
+/*
+TestRunShell is not really a test; it is a convenient way to use the registry setup code
+in openshift.go and CopySuite to get an interactive environment for experimentation.
+
+To use it, run:
+	sudo make shell
+to start a container, then within the container:
+	SKOPEO_CONTAINER_TESTS=1 PS1='nested> ' go test -tags openshift_shell -timeout=24h ./integration -v -check.v -check.vv -check.f='CopySuite.TestRunShell'
+
+An example of what can be done within the container:
+	cd ..; make binary-local install
+	./skopeo --tls-verify=false  copy --sign-by=personal@example.com docker://busybox:latest atomic:localhost:5000/myns/personal:personal
+	oc get istag personal:personal -o json
+	curl -L -v 'http://localhost:5000/v2/'
+	cat ~/.docker/config.json
+	curl -L -v 'http://localhost:5000/openshift/token&scope=repository:myns/personal:pull' --header 'Authorization: Basic $auth_from_docker'
+	curl -L -v 'http://localhost:5000/v2/myns/personal/manifests/personal' --header 'Authorization: Bearer $token_from_oauth'
+	curl -L -v 'http://localhost:5000/extensions/v2/myns/personal/signatures/$manifest_digest' --header 'Authorization: Bearer $token_from_oauth'
+*/
+func (s *CopySuite) TestRunShell(c *check.C) {
+	cmd := exec.Command("bash", "-i")
+	tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
+	c.Assert(err, check.IsNil)
+	cmd.Stdin = tty
+	cmd.Stdout = tty
+	cmd.Stderr = tty
+	err = cmd.Run()
+	c.Assert(err, check.IsNil)
+}


### PR DESCRIPTION
We are maintaining code to set up and run registries, including the fairly complex setup for Atomic Registry, in the integration tests. This is all useful for experimentation in shell, and the easiest way to
do that is to add a “test” which, after all the set up is done, simply starts a shell.

Obviously this is commented out and thus does not affect ordinary test runs.

A possible alternative would be to convert all of the setup code not to depend on `check.C` and `testing.T`, but that would be fairly cumbersome due to how prevalent `c.Logf` and `c.Assert` are throughout the setup code. Especially the natural replacement of `c.Assert` with a `panic()` would be
pretty ugly, and adding real error handling to all of that would make the code noticeably longer.  Commenting/uncommenting a function and copy&pasting a command works just as well, at least for now.

(It is not conveniently possible to create a new “main program” which manually creates a `check.C` and `testing.T` just for the purpose of running the setup code either; `check.C` can be created given a `testing.T`, but `testing.T` is only created by `testing.MainStart`, which does not allow us to submit a non-test method and `testing.MainStart` is excluded from the Go compatibility promise.)