### PR TITLE
Trivial bug fixes to `CopySuite.TestCopyDockerSigstore`

### DIFF
--- a/integration/copy_test.go
+++ b/integration/copy_test.go
@@ -394,7 +394,7 @@ func (s *CopySuite) TestCopyDockerSigstore(c *check.C) {
 
 	tmpDir, err := ioutil.TempDir("", "signatures-sigstore")
 	c.Assert(err, check.IsNil)
-	//defer os.RemoveAll(tmpDir)
+	defer os.RemoveAll(tmpDir)
 	copyDest := filepath.Join(tmpDir, "dest")
 	err = os.Mkdir(copyDest, 0755)
 	c.Assert(err, check.IsNil)

--- a/integration/copy_test.go
+++ b/integration/copy_test.go
@@ -435,7 +435,6 @@ func (s *CopySuite) TestCopyDockerSigstore(c *check.C) {
 	// Deleting the image succeeds,
 	assertSkopeoSucceeds(c, "", "--tls-verify=false", "--registries.d", registriesDir, "delete", ourRegistry+"signed/busybox")
 	// and the signature file has been deleted (but we leave the directories around).
-	// a signature file has been created,
 	foundFiles = findRegularFiles(c, plainSigstore)
 	c.Assert(foundFiles, check.HasLen, 0)
 


### PR DESCRIPTION
- Uncomment an `os.RemoveAll(tmpDir)`
- Remove a copy&pasted comment