### PR TITLE
Simplify infrastructure setup, and make registry timeouts less strict

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,20 +6,12 @@ RUN dnf -y update && dnf install -y make git golang golang-github-cpuguy83-go-md
 	device-mapper-devel \
 	# gpgme bindings deps
 	libassuan-devel gpgme-devel \
-	gnupg \
-	# registry v1 deps
-	xz-devel \
-	python-devel \
-	python-pip \
-	swig \
-	redhat-rpm-config \
-	openssl-devel \
-	patch
+	gnupg
 
-# Install three versions of the registry. The first is an older version that
+# Install two versions of the registry. The first is an older version that
 # only supports schema1 manifests. The second is a newer version that supports
 # both. This allows integration-cli tests to cover push/pull with both schema1
-# and schema2 manifests. Install registry v1 also.
+# and schema2 manifests.
 ENV REGISTRY_COMMIT_SCHEMA1 ec87e9b6971d831f0eff752ddb54fb64693e51cd
 ENV REGISTRY_COMMIT 47a064d4195a9b56133891bbb13620c3ac83a827
 RUN set -x \
@@ -31,17 +23,7 @@ RUN set -x \
 	&& (cd "$GOPATH/src/github.com/docker/distribution" && git checkout -q "$REGISTRY_COMMIT_SCHEMA1") \
 	&& GOPATH="$GOPATH/src/github.com/docker/distribution/Godeps/_workspace:$GOPATH" \
 		go build -o /usr/local/bin/registry-v2-schema1 github.com/docker/distribution/cmd/registry \
-	&& rm -rf "$GOPATH" \
-	&& export DRV1="$(mktemp -d)" \
-	&& git clone https://github.com/docker/docker-registry.git "$DRV1" \
-	# no need for setuptools since we have a version conflict with fedora
-	&& sed -i.bak s/setuptools==5.8//g "$DRV1/requirements/main.txt" \
-	&& sed -i.bak s/setuptools==5.8//g "$DRV1/depends/docker-registry-core/requirements/main.txt" \
-	&& pip install "$DRV1/depends/docker-registry-core" \
-	&& pip install file://"$DRV1#egg=docker-registry[bugsnag,newrelic,cors]" \
-	&& patch $(python -c 'import boto; import os; print os.path.dirname(boto.__file__)')/connection.py \
-		< "$DRV1/contrib/boto_header_patch.diff" \
-	&& dnf -y update && dnf install -y m2crypto
+	&& rm -rf "$GOPATH"
 
 RUN set -x \
 	&& yum install -y which git tar wget hostname util-linux bsdtar socat ethtool device-mapper iptables tree findutils nmap-ncat e2fsprogs xfsprogs lsof docker iproute \

--- a/integration/check_test.go
+++ b/integration/check_test.go
@@ -12,9 +12,6 @@ import (
 const (
 	privateRegistryURL0 = "127.0.0.1:5000"
 	privateRegistryURL1 = "127.0.0.1:5001"
-	privateRegistryURL2 = "127.0.0.1:5002"
-	privateRegistryURL3 = "127.0.0.1:5003"
-	privateRegistryURL4 = "127.0.0.1:5004"
 )
 
 func Test(t *testing.T) {
@@ -26,10 +23,7 @@ func init() {
 }
 
 type SkopeoSuite struct {
-	regV1         *testRegistryV1
 	regV2         *testRegistryV2
-	regV2Shema1   *testRegistryV2
-	regV1WithAuth *testRegistryV1 // does v1 support auth?
 	regV2WithAuth *testRegistryV2
 }
 
@@ -43,20 +37,13 @@ func (s *SkopeoSuite) TearDownSuite(c *check.C) {
 }
 
 func (s *SkopeoSuite) SetUpTest(c *check.C) {
-	s.regV1 = setupRegistryV1At(c, privateRegistryURL0, false) // TODO:(runcom)
-	s.regV2 = setupRegistryV2At(c, privateRegistryURL1, false, false)
-	s.regV2Shema1 = setupRegistryV2At(c, privateRegistryURL2, false, true)
-	s.regV1WithAuth = setupRegistryV1At(c, privateRegistryURL3, true) // not used
-	s.regV2WithAuth = setupRegistryV2At(c, privateRegistryURL4, true, false)
+	s.regV2 = setupRegistryV2At(c, privateRegistryURL0, false, false)
+	s.regV2WithAuth = setupRegistryV2At(c, privateRegistryURL1, true, false)
 }
 
 func (s *SkopeoSuite) TearDownTest(c *check.C) {
-	// not checking V1 registries now...
 	if s.regV2 != nil {
 		s.regV2.Close()
-	}
-	if s.regV2Shema1 != nil {
-		s.regV2Shema1.Close()
 	}
 	if s.regV2WithAuth != nil {
 		//cmd := exec.Command("docker", "logout", s.regV2WithAuth)

--- a/integration/check_test.go
+++ b/integration/check_test.go
@@ -34,7 +34,8 @@ type SkopeoSuite struct {
 }
 
 func (s *SkopeoSuite) SetUpSuite(c *check.C) {
-
+	_, err := exec.LookPath(skopeoBinary)
+	c.Assert(err, check.IsNil)
 }
 
 func (s *SkopeoSuite) TearDownSuite(c *check.C) {
@@ -42,9 +43,6 @@ func (s *SkopeoSuite) TearDownSuite(c *check.C) {
 }
 
 func (s *SkopeoSuite) SetUpTest(c *check.C) {
-	_, err := exec.LookPath(skopeoBinary)
-	c.Assert(err, check.IsNil)
-
 	s.regV1 = setupRegistryV1At(c, privateRegistryURL0, false) // TODO:(runcom)
 	s.regV2 = setupRegistryV2At(c, privateRegistryURL1, false, false)
 	s.regV2Shema1 = setupRegistryV2At(c, privateRegistryURL2, false, true)

--- a/integration/registry.go
+++ b/integration/registry.go
@@ -13,22 +13,9 @@ import (
 )
 
 const (
-	binaryV1        = "docker-registry"
 	binaryV2        = "registry-v2"
 	binaryV2Schema1 = "registry-v2-schema1"
 )
-
-type testRegistryV1 struct {
-	cmd *exec.Cmd
-	url string
-	dir string
-}
-
-func setupRegistryV1At(c *check.C, url string, auth bool) *testRegistryV1 {
-	return &testRegistryV1{
-		url: url,
-	}
-}
 
 type testRegistryV2 struct {
 	cmd      *exec.Cmd

--- a/integration/registry.go
+++ b/integration/registry.go
@@ -31,7 +31,7 @@ func setupRegistryV2At(c *check.C, url string, auth, schema1 bool) *testRegistry
 	c.Assert(err, check.IsNil)
 
 	// Wait for registry to be ready to serve requests.
-	for i := 0; i != 5; i++ {
+	for i := 0; i != 50; i++ {
 		if err = reg.Ping(); err == nil {
 			break
 		}

--- a/integration/signing_test.go
+++ b/integration/signing_test.go
@@ -39,15 +39,6 @@ func findFingerprint(lineBytes []byte) (string, error) {
 func (s *SigningSuite) SetUpSuite(c *check.C) {
 	_, err := exec.LookPath(skopeoBinary)
 	c.Assert(err, check.IsNil)
-}
-
-func (s *SigningSuite) SetUpTest(c *check.C) {
-	mech, _, err := signature.NewEphemeralGPGSigningMechanism([]byte{})
-	c.Assert(err, check.IsNil)
-	defer mech.Close()
-	if err := mech.SupportsSigning(); err != nil { // FIXME? Test that verification and policy enforcement works, using signatures from fixtures
-		c.Skip(fmt.Sprintf("Signing not supported: %v", err))
-	}
 
 	s.gpgHome, err = ioutil.TempDir("", "skopeo-gpg")
 	c.Assert(err, check.IsNil)
@@ -61,7 +52,7 @@ func (s *SigningSuite) SetUpTest(c *check.C) {
 	c.Assert(err, check.IsNil)
 }
 
-func (s *SigningSuite) TearDownTest(c *check.C) {
+func (s *SigningSuite) TearDownSuite(c *check.C) {
 	if s.gpgHome != "" {
 		err := os.RemoveAll(s.gpgHome)
 		c.Assert(err, check.IsNil)
@@ -72,6 +63,13 @@ func (s *SigningSuite) TearDownTest(c *check.C) {
 }
 
 func (s *SigningSuite) TestSignVerifySmoke(c *check.C) {
+	mech, _, err := signature.NewEphemeralGPGSigningMechanism([]byte{})
+	c.Assert(err, check.IsNil)
+	defer mech.Close()
+	if err := mech.SupportsSigning(); err != nil { // FIXME? Test that verification and policy enforcement works, using signatures from fixtures
+		c.Skip(fmt.Sprintf("Signing not supported: %v", err))
+	}
+
 	manifestPath := "fixtures/image.manifest.json"
 	dockerReference := "testing/smoketest"
 

--- a/integration/signing_test.go
+++ b/integration/signing_test.go
@@ -36,6 +36,11 @@ func findFingerprint(lineBytes []byte) (string, error) {
 	return "", errors.New("No fingerprint found")
 }
 
+func (s *SigningSuite) SetUpSuite(c *check.C) {
+	_, err := exec.LookPath(skopeoBinary)
+	c.Assert(err, check.IsNil)
+}
+
 func (s *SigningSuite) SetUpTest(c *check.C) {
 	mech, _, err := signature.NewEphemeralGPGSigningMechanism([]byte{})
 	c.Assert(err, check.IsNil)
@@ -43,9 +48,6 @@ func (s *SigningSuite) SetUpTest(c *check.C) {
 	if err := mech.SupportsSigning(); err != nil { // FIXME? Test that verification and policy enforcement works, using signatures from fixtures
 		c.Skip(fmt.Sprintf("Signing not supported: %v", err))
 	}
-
-	_, err = exec.LookPath(skopeoBinary)
-	c.Assert(err, check.IsNil)
 
 	s.gpgHome, err = ioutil.TempDir("", "skopeo-gpg")
 	c.Assert(err, check.IsNil)


### PR DESCRIPTION
This moves various setup steps from `SetUpTest` to `SetUpSuite` so that we don’t start up processes over and over; that is _slightly_ less reliable, but more efficient.

Also increases the registry startup timeout from 0.5 to 5 seconds, hopefully avoiding some CI flakes.

Finally, completely stops starting some of the registries which we don’t use, with an `if false` to keep the existing code structure. (Alternatively we could drop that, and stop building the docker/registry code altogether.