### PR TITLE
Always combine RUN apt-get update with apt-get install in the same RUN statement.

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,5 +1,12 @@
 FROM ubuntu:16.04
-RUN apt-get update
-RUN apt-get install -y golang btrfs-tools git-core libdevmapper-dev libgpgme11-dev go-md2man
+
+RUN apt-get update && apt-get install -y \
+    golang \
+    btrfs-tools \
+    git-core \
+    libdevmapper-dev \
+    libgpgme11-dev \
+    go-md2man
+
 ENV GOPATH=/
 WORKDIR /src/github.com/projectatomic/skopeo


### PR DESCRIPTION
From the [docs](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#build-cache) in March 2017:

Always combine `RUN apt-get update` with `apt-get install` in the same  RUN statement, for example

`RUN apt-get update && apt-get install -y package-bar`

Using `apt-get update` alone in a RUN statement causes caching issues and subsequent` apt-get install `instructions fail.

Signed-off-by: Jing Qiu <aqiu0720@gmail.com>