### PR TITLE
Added go-md2man to fix build process from source.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ RUN set -x \
 ENV GOPATH /usr/share/gocode:/go
 ENV PATH $GOPATH/bin:/usr/share/gocode/bin:$PATH
 RUN go get github.com/golang/lint/golint
+RUN go get github.com/cpuguy83/go-md2man
 WORKDIR /go/src/github.com/projectatomic/skopeo
 COPY . /go/src/github.com/projectatomic/skopeo
 


### PR DESCRIPTION
I tried to build skopeo from source:

```bash
go get github.com/projectatomic/skopeo
cd $GOPATH/github.com/projectatomic/skopeo
make
```

This was the output.

```
Step 4/4 : WORKDIR /src/github.com/projectatomic/skopeo
 ---> b5eab880bf01
 Removing intermediate container 6695eac353b8
 Successfully built b5eab880bf01
 docker run --rm --security-opt label:disable -v
 $(pwd):/src/github.com/projectatomic/skopeo \
 skopeobuildimage make binary-local  BUILDTAGS='
 libdm_no_deferred_remove'
 go build -ldflags "-X
 main.gitCommit=f0d830a8ca959076ee3b78c71d861972a734c036"
 -gcflags "" -tags "libdm_no_deferred_remove" -o skopeo
 ./cmd/skopeo
 go-md2man -in docs/skopeo.1.md -out docs/skopeo.1.tmp && touch
 docs/skopeo.1.tmp && mv docs/skopeo.1.tmp docs/skopeo.1
 /bin/sh: 1: go-md2man: not found
 Makefile:69: recipe for target 'docs/skopeo.1' failed
 make: *** [docs/skopeo.1] Error 127
```

I added `go-md2man`.
Thanks a lot for your work!