### PR TITLE
Update for removal of requestedMIMETypes from ImageReference.NewImageSource()

### DIFF
--- a/cmd/skopeo/layers.go
+++ b/cmd/skopeo/layers.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/containers/image/directory"
 	"github.com/containers/image/image"
-	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
 	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
@@ -25,12 +24,7 @@ var layersCmd = cli.Command{
 		if c.NArg() == 0 {
 			return errors.New("Usage: layers imageReference [layer...]")
 		}
-		rawSource, err := parseImageSource(c, c.Args()[0], []string{
-			// TODO: skopeo layers only supports these now
-			// eventually we'll remove this command altogether...
-			manifest.DockerV2Schema1SignedMediaType,
-			manifest.DockerV2Schema1MediaType,
-		})
+		rawSource, err := parseImageSource(c, c.Args()[0])
 		if err != nil {
 			return err
 		}

--- a/cmd/skopeo/utils.go
+++ b/cmd/skopeo/utils.go
@@ -72,9 +72,8 @@ func parseImage(c *cli.Context) (types.Image, error) {
 }
 
 // parseImageSource converts image URL-like string to an ImageSource.
-// requestedManifestMIMETypes is as in types.ImageReference.NewImageSource.
 // The caller must call .Close() on the returned ImageSource.
-func parseImageSource(c *cli.Context, name string, requestedManifestMIMETypes []string) (types.ImageSource, error) {
+func parseImageSource(c *cli.Context, name string) (types.ImageSource, error) {
 	ref, err := alltransports.ParseImageName(name)
 	if err != nil {
 		return nil, err
@@ -83,5 +82,5 @@ func parseImageSource(c *cli.Context, name string, requestedManifestMIMETypes []
 	if err != nil {
 		return nil, err
 	}
-	return ref.NewImageSource(ctx, requestedManifestMIMETypes)
+	return ref.NewImageSource(ctx)
 }

--- a/vendor/github.com/containers/image/copy/copy.go
+++ b/vendor/github.com/containers/image/copy/copy.go
@@ -129,9 +129,7 @@ func Image(policyContext *signature.PolicyContext, destRef, srcRef types.ImageRe
 		}
 	}()
 
-	destSupportedManifestMIMETypes := dest.SupportedManifestMIMETypes()
-
-	rawSource, err := srcRef.NewImageSource(options.SourceCtx, destSupportedManifestMIMETypes)
+	rawSource, err := srcRef.NewImageSource(options.SourceCtx)
 	if err != nil {
 		return errors.Wrapf(err, "Error initializing source %s", transports.ImageName(srcRef))
 	}
@@ -195,7 +193,7 @@ func Image(policyContext *signature.PolicyContext, destRef, srcRef types.ImageRe
 
 	// We compute preferredManifestMIMEType only to show it in error messages.
 	// Without having to add this context in an error message, we would be happy enough to know only that no conversion is needed.
-	preferredManifestMIMEType, otherManifestMIMETypeCandidates, err := determineManifestConversion(&manifestUpdates, src, destSupportedManifestMIMETypes, canModifyManifest)
+	preferredManifestMIMEType, otherManifestMIMETypeCandidates, err := determineManifestConversion(&manifestUpdates, src, dest.SupportedManifestMIMETypes(), canModifyManifest)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/containers/image/directory/directory_transport.go
+++ b/vendor/github.com/containers/image/directory/directory_transport.go
@@ -143,11 +143,9 @@ func (ref dirReference) NewImage(ctx *types.SystemContext) (types.Image, error) 
 	return image.FromSource(src)
 }
 
-// NewImageSource returns a types.ImageSource for this reference,
-// asking the backend to use a manifest from requestedManifestMIMETypes if possible.
-// nil requestedManifestMIMETypes means manifest.DefaultRequestedManifestMIMETypes.
+// NewImageSource returns a types.ImageSource for this reference.
 // The caller must call .Close() on the returned ImageSource.
-func (ref dirReference) NewImageSource(ctx *types.SystemContext, requestedManifestMIMETypes []string) (types.ImageSource, error) {
+func (ref dirReference) NewImageSource(ctx *types.SystemContext) (types.ImageSource, error) {
 	return newImageSource(ref), nil
 }
 

--- a/vendor/github.com/containers/image/docker/archive/transport.go
+++ b/vendor/github.com/containers/image/docker/archive/transport.go
@@ -134,11 +134,9 @@ func (ref archiveReference) NewImage(ctx *types.SystemContext) (types.Image, err
 	return ctrImage.FromSource(src)
 }
 
-// NewImageSource returns a types.ImageSource for this reference,
-// asking the backend to use a manifest from requestedManifestMIMETypes if possible.
-// nil requestedManifestMIMETypes means manifest.DefaultRequestedManifestMIMETypes.
+// NewImageSource returns a types.ImageSource for this reference.
 // The caller must call .Close() on the returned ImageSource.
-func (ref archiveReference) NewImageSource(ctx *types.SystemContext, requestedManifestMIMETypes []string) (types.ImageSource, error) {
+func (ref archiveReference) NewImageSource(ctx *types.SystemContext) (types.ImageSource, error) {
 	return newImageSource(ctx, ref), nil
 }
 

--- a/vendor/github.com/containers/image/docker/daemon/daemon_transport.go
+++ b/vendor/github.com/containers/image/docker/daemon/daemon_transport.go
@@ -161,11 +161,9 @@ func (ref daemonReference) NewImage(ctx *types.SystemContext) (types.Image, erro
 	return image.FromSource(src)
 }
 
-// NewImageSource returns a types.ImageSource for this reference,
-// asking the backend to use a manifest from requestedManifestMIMETypes if possible.
-// nil requestedManifestMIMETypes means manifest.DefaultRequestedManifestMIMETypes.
+// NewImageSource returns a types.ImageSource for this reference.
 // The caller must call .Close() on the returned ImageSource.
-func (ref daemonReference) NewImageSource(ctx *types.SystemContext, requestedManifestMIMETypes []string) (types.ImageSource, error) {
+func (ref daemonReference) NewImageSource(ctx *types.SystemContext) (types.ImageSource, error) {
 	return newImageSource(ctx, ref)
 }
 

--- a/vendor/github.com/containers/image/docker/docker_image.go
+++ b/vendor/github.com/containers/image/docker/docker_image.go
@@ -23,7 +23,7 @@ type Image struct {
 // a client to the registry hosting the given image.
 // The caller must call .Close() on the returned Image.
 func newImage(ctx *types.SystemContext, ref dockerReference) (types.Image, error) {
-	s, err := newImageSource(ctx, ref, nil)
+	s, err := newImageSource(ctx, ref)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/containers/image/docker/docker_image_dest.go
+++ b/vendor/github.com/containers/image/docker/docker_image_dest.go
@@ -20,24 +20,10 @@ import (
 	"github.com/docker/distribution/registry/api/v2"
 	"github.com/docker/distribution/registry/client"
 	"github.com/opencontainers/go-digest"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
-
-var manifestMIMETypes = []string{
-	// TODO(runcom): we'll add OCI as part of another PR here
-	manifest.DockerV2Schema2MediaType,
-	manifest.DockerV2Schema1SignedMediaType,
-	manifest.DockerV2Schema1MediaType,
-}
-
-func supportedManifestMIMETypesMap() map[string]bool {
-	m := make(map[string]bool, len(manifestMIMETypes))
-	for _, mt := range manifestMIMETypes {
-		m[mt] = true
-	}
-	return m
-}
 
 type dockerImageDestination struct {
 	ref dockerReference
@@ -70,7 +56,12 @@ func (d *dockerImageDestination) Close() error {
 }
 
 func (d *dockerImageDestination) SupportedManifestMIMETypes() []string {
-	return manifestMIMETypes
+	return []string{
+		imgspecv1.MediaTypeImageManifest,
+		manifest.DockerV2Schema2MediaType,
+		manifest.DockerV2Schema1SignedMediaType,
+		manifest.DockerV2Schema1MediaType,
+	}
 }
 
 // SupportsSignatures returns an error (to be displayed to the user) if the destination certainly can't store signatures.

--- a/vendor/github.com/containers/image/docker/docker_transport.go
+++ b/vendor/github.com/containers/image/docker/docker_transport.go
@@ -130,12 +130,10 @@ func (ref dockerReference) NewImage(ctx *types.SystemContext) (types.Image, erro
 	return newImage(ctx, ref)
 }
 
-// NewImageSource returns a types.ImageSource for this reference,
-// asking the backend to use a manifest from requestedManifestMIMETypes if possible.
-// nil requestedManifestMIMETypes means manifest.DefaultRequestedManifestMIMETypes.
+// NewImageSource returns a types.ImageSource for this reference.
 // The caller must call .Close() on the returned ImageSource.
-func (ref dockerReference) NewImageSource(ctx *types.SystemContext, requestedManifestMIMETypes []string) (types.ImageSource, error) {
-	return newImageSource(ctx, ref, requestedManifestMIMETypes)
+func (ref dockerReference) NewImageSource(ctx *types.SystemContext) (types.ImageSource, error) {
+	return newImageSource(ctx, ref)
 }
 
 // NewImageDestination returns a types.ImageDestination for this reference.

--- a/vendor/github.com/containers/image/oci/archive/oci_src.go
+++ b/vendor/github.com/containers/image/oci/archive/oci_src.go
@@ -19,13 +19,13 @@ type ociArchiveImageSource struct {
 
 // newImageSource returns an ImageSource for reading from an existing directory.
 // newImageSource untars the file and saves it in a temp directory
-func newImageSource(ctx *types.SystemContext, ref ociArchiveReference, requestedManifestMIMETypes []string) (types.ImageSource, error) {
+func newImageSource(ctx *types.SystemContext, ref ociArchiveReference) (types.ImageSource, error) {
 	tempDirRef, err := createUntarTempDir(ref)
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating temp directory")
 	}
 
-	unpackedSrc, err := tempDirRef.ociRefExtracted.NewImageSource(ctx, requestedManifestMIMETypes)
+	unpackedSrc, err := tempDirRef.ociRefExtracted.NewImageSource(ctx)
 	if err != nil {
 		if err := tempDirRef.deleteTempDir(); err != nil {
 			return nil, errors.Wrapf(err, "error deleting temp directory", tempDirRef.tempDirectory)

--- a/vendor/github.com/containers/image/oci/archive/oci_transport.go
+++ b/vendor/github.com/containers/image/oci/archive/oci_transport.go
@@ -157,18 +157,17 @@ func (ref ociArchiveReference) PolicyConfigurationNamespaces() []string {
 // NewImage returns a types.Image for this reference, possibly specialized for this ImageTransport.
 // The caller must call .Close() on the returned Image.
 func (ref ociArchiveReference) NewImage(ctx *types.SystemContext) (types.Image, error) {
-	src, err := newImageSource(ctx, ref, nil)
+	src, err := newImageSource(ctx, ref)
 	if err != nil {
 		return nil, err
 	}
 	return image.FromSource(src)
 }
 
-// NewImageSource returns a types.ImageSource for this reference,
-// asking the backend to use a manifest from requestedManifestMIMETypes if possible.
+// NewImageSource returns a types.ImageSource for this reference.
 // The caller must call .Close() on the returned ImageSource.
-func (ref ociArchiveReference) NewImageSource(ctx *types.SystemContext, requestedManifestMIMETypes []string) (types.ImageSource, error) {
-	return newImageSource(ctx, ref, requestedManifestMIMETypes)
+func (ref ociArchiveReference) NewImageSource(ctx *types.SystemContext) (types.ImageSource, error) {
+	return newImageSource(ctx, ref)
 }
 
 // NewImageDestination returns a types.ImageDestination for this reference.

--- a/vendor/github.com/containers/image/oci/layout/oci_transport.go
+++ b/vendor/github.com/containers/image/oci/layout/oci_transport.go
@@ -241,11 +241,9 @@ func LoadManifestDescriptor(imgRef types.ImageReference) (imgspecv1.Descriptor, 
 	return ociRef.getManifestDescriptor()
 }
 
-// NewImageSource returns a types.ImageSource for this reference,
-// asking the backend to use a manifest from requestedManifestMIMETypes if possible.
-// nil requestedManifestMIMETypes means manifest.DefaultRequestedManifestMIMETypes.
+// NewImageSource returns a types.ImageSource for this reference.
 // The caller must call .Close() on the returned ImageSource.
-func (ref ociReference) NewImageSource(ctx *types.SystemContext, requestedManifestMIMETypes []string) (types.ImageSource, error) {
+func (ref ociReference) NewImageSource(ctx *types.SystemContext) (types.ImageSource, error) {
 	return newImageSource(ref)
 }
 

--- a/vendor/github.com/containers/image/openshift/openshift.go
+++ b/vendor/github.com/containers/image/openshift/openshift.go
@@ -162,18 +162,15 @@ func (c *openshiftClient) convertDockerImageReference(ref string) (string, error
 type openshiftImageSource struct {
 	client *openshiftClient
 	// Values specific to this image
-	ctx                        *types.SystemContext
-	requestedManifestMIMETypes []string
+	ctx *types.SystemContext
 	// State
 	docker               types.ImageSource // The Docker Registry endpoint, or nil if not resolved yet
 	imageStreamImageName string            // Resolved image identifier, or "" if not known yet
 }
 
-// newImageSource creates a new ImageSource for the specified reference,
-// asking the backend to use a manifest from requestedManifestMIMETypes if possible.
-// nil requestedManifestMIMETypes means manifest.DefaultRequestedManifestMIMETypes.
+// newImageSource creates a new ImageSource for the specified reference.
 // The caller must call .Close() on the returned ImageSource.
-func newImageSource(ctx *types.SystemContext, ref openshiftReference, requestedManifestMIMETypes []string) (types.ImageSource, error) {
+func newImageSource(ctx *types.SystemContext, ref openshiftReference) (types.ImageSource, error) {
 	client, err := newOpenshiftClient(ref)
 	if err != nil {
 		return nil, err
@@ -182,7 +179,6 @@ func newImageSource(ctx *types.SystemContext, ref openshiftReference, requestedM
 	return &openshiftImageSource{
 		client: client,
 		ctx:    ctx,
-		requestedManifestMIMETypes: requestedManifestMIMETypes,
 	}, nil
 }
 
@@ -286,7 +282,7 @@ func (s *openshiftImageSource) ensureImageIsResolved(ctx context.Context) error 
 	if err != nil {
 		return err
 	}
-	d, err := dockerRef.NewImageSource(s.ctx, s.requestedManifestMIMETypes)
+	d, err := dockerRef.NewImageSource(s.ctx)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/containers/image/openshift/openshift_transport.go
+++ b/vendor/github.com/containers/image/openshift/openshift_transport.go
@@ -130,19 +130,17 @@ func (ref openshiftReference) PolicyConfigurationNamespaces() []string {
 // NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
 // verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
 func (ref openshiftReference) NewImage(ctx *types.SystemContext) (types.Image, error) {
-	src, err := newImageSource(ctx, ref, nil)
+	src, err := newImageSource(ctx, ref)
 	if err != nil {
 		return nil, err
 	}
 	return genericImage.FromSource(src)
 }
 
-// NewImageSource returns a types.ImageSource for this reference,
-// asking the backend to use a manifest from requestedManifestMIMETypes if possible.
-// nil requestedManifestMIMETypes means manifest.DefaultRequestedManifestMIMETypes.
+// NewImageSource returns a types.ImageSource for this reference.
 // The caller must call .Close() on the returned ImageSource.
-func (ref openshiftReference) NewImageSource(ctx *types.SystemContext, requestedManifestMIMETypes []string) (types.ImageSource, error) {
-	return newImageSource(ctx, ref, requestedManifestMIMETypes)
+func (ref openshiftReference) NewImageSource(ctx *types.SystemContext) (types.ImageSource, error) {
+	return newImageSource(ctx, ref)
 }
 
 // NewImageDestination returns a types.ImageDestination for this reference.

--- a/vendor/github.com/containers/image/ostree/ostree_transport.go
+++ b/vendor/github.com/containers/image/ostree/ostree_transport.go
@@ -185,11 +185,9 @@ func (ref ostreeReference) NewImage(ctx *types.SystemContext) (types.Image, erro
 	return nil, errors.New("Reading ostree: images is currently not supported")
 }
 
-// NewImageSource returns a types.ImageSource for this reference,
-// asking the backend to use a manifest from requestedManifestMIMETypes if possible.
-// nil requestedManifestMIMETypes means manifest.DefaultRequestedManifestMIMETypes.
+// NewImageSource returns a types.ImageSource for this reference.
 // The caller must call .Close() on the returned ImageSource.
-func (ref ostreeReference) NewImageSource(ctx *types.SystemContext, requestedManifestMIMETypes []string) (types.ImageSource, error) {
+func (ref ostreeReference) NewImageSource(ctx *types.SystemContext) (types.ImageSource, error) {
 	return nil, errors.New("Reading ostree: images is currently not supported")
 }
 

--- a/vendor/github.com/containers/image/storage/storage_reference.go
+++ b/vendor/github.com/containers/image/storage/storage_reference.go
@@ -154,7 +154,7 @@ func (s storageReference) DeleteImage(ctx *types.SystemContext) error {
 	return err
 }
 
-func (s storageReference) NewImageSource(ctx *types.SystemContext, requestedManifestMIMETypes []string) (types.ImageSource, error) {
+func (s storageReference) NewImageSource(ctx *types.SystemContext) (types.ImageSource, error) {
 	return newImageSource(s)
 }
 

--- a/vendor/github.com/containers/image/types/types.go
+++ b/vendor/github.com/containers/image/types/types.go
@@ -78,11 +78,9 @@ type ImageReference interface {
 	// NOTE: If any kind of signature verification should happen, build an UnparsedImage from the value returned by NewImageSource,
 	// verify that UnparsedImage, and convert it into a real Image via image.FromUnparsedImage.
 	NewImage(ctx *SystemContext) (Image, error)
-	// NewImageSource returns a types.ImageSource for this reference,
-	// asking the backend to use a manifest from requestedManifestMIMETypes if possible.
-	// nil requestedManifestMIMETypes means manifest.DefaultRequestedManifestMIMETypes.
+	// NewImageSource returns a types.ImageSource for this reference.
 	// The caller must call .Close() on the returned ImageSource.
-	NewImageSource(ctx *SystemContext, requestedManifestMIMETypes []string) (ImageSource, error)
+	NewImageSource(ctx *SystemContext) (ImageSource, error)
 	// NewImageDestination returns a types.ImageDestination for this reference.
 	// The caller must call .Close() on the returned ImageDestination.
 	NewImageDestination(ctx *SystemContext) (ImageDestination, error)


### PR DESCRIPTION
This makes skopeo compile (and pass tests) with the change to ImageReference.NewImageSource in https://github.com/containers/image/pull/338