### PR TITLE
Create thin Docker Alpine skopeo image

### DIFF
--- a/Dockerfile.ms
+++ b/Dockerfile.ms
@@ -1,28 +1,4 @@
 #
-# ----- Go Builder Image ------
-#
-# FROM golang:1.9 AS builder
-
-# RUN apt-get update && apt-get install -y \
-#     btrfs-tools \
-#     git-core \
-#     libdevmapper-dev \
-#     libgpgme11-dev \
-#     go-md2man \
-#     libglib2.0-dev \
-#     libostree-dev
-
-# # set working directory
-# RUN mkdir -p /go/src/github.com/projectatomic/skopeo
-# WORKDIR /go/src/github.com/projectatomic/skopeo
-
-# # copy sources (including .git repo)
-# COPY . .
-
-# # set entrypoint to bash
-# ENTRYPOINT ["/bin/bash"]
-
-#
 # ----- Go Builder Alpine Image ------
 #
 FROM golang:1.9-alpine AS builder
@@ -45,9 +21,6 @@ WORKDIR /go/src/github.com/projectatomic/skopeo
 
 # copy sources (including .git repo)
 COPY . .
-
-# set entrypoint to bash
-ENTRYPOINT ["/bin/bash"]
 
 # run test and calculate coverage: skip for RELEASE
 RUN make binary-local
@@ -84,4 +57,6 @@ RUN apk add --no-cache \
 
 RUN apk add --no-cache -X http://nl.alpinelinux.org/alpine/edge/testing ostree
 
-COPY --from=builder /go/src/github.com/projectatomic/skopeo/skopeo /usr/bin/skopeo
+COPY --from=builder /go/src/github.com/projectatomic/skopeo/skopeo /usr/local/bin/skopeo
+
+CMD ["/usr/local/bin/skopeo", "--help"]

--- a/Dockerfile.ms
+++ b/Dockerfile.ms
@@ -1,0 +1,87 @@
+#
+# ----- Go Builder Image ------
+#
+# FROM golang:1.9 AS builder
+
+# RUN apt-get update && apt-get install -y \
+#     btrfs-tools \
+#     git-core \
+#     libdevmapper-dev \
+#     libgpgme11-dev \
+#     go-md2man \
+#     libglib2.0-dev \
+#     libostree-dev
+
+# # set working directory
+# RUN mkdir -p /go/src/github.com/projectatomic/skopeo
+# WORKDIR /go/src/github.com/projectatomic/skopeo
+
+# # copy sources (including .git repo)
+# COPY . .
+
+# # set entrypoint to bash
+# ENTRYPOINT ["/bin/bash"]
+
+#
+# ----- Go Builder Alpine Image ------
+#
+FROM golang:1.9-alpine AS builder
+
+RUN apk add --no-cache git bash || apk update && apk upgrade
+RUN apk add --no-cache make gcc python2 perl || apk update && apk upgrade
+
+RUN apk add --no-cache \
+    musl-dev \
+    btrfs-progs-dev \
+    lvm2-dev \
+    gpgme-dev \
+    glib-dev || apk update && apk upgrade
+
+RUN apk add --no-cache -X http://nl.alpinelinux.org/alpine/edge/testing ostree-dev
+
+# set working directory
+RUN mkdir -p /go/src/github.com/projectatomic/skopeo
+WORKDIR /go/src/github.com/projectatomic/skopeo
+
+# copy sources (including .git repo)
+COPY . .
+
+# set entrypoint to bash
+ENTRYPOINT ["/bin/bash"]
+
+# run test and calculate coverage: skip for RELEASE
+RUN make binary-local
+
+#
+# ------ Pumba runtime image ------
+#
+FROM alpine:3.6
+
+RUN apk add --no-cache \
+    device-mapper-libs \
+    gpgme \
+    glib \
+    expat \
+    libacl \
+    libarchive \
+    libassuan \
+    libattr \
+    libblkid \
+    libbz2 \
+    libffi \
+    libgpg-error \
+    libintl \
+    libmount \
+    libressl2.5-libcrypto \
+    libsoup \
+    libuuid \
+    libxml2 \
+    lz4-libs \
+    pcre \
+    sqlite-libs \
+    xz-libs \
+    zlib || apk update && apk upgrade
+
+RUN apk add --no-cache -X http://nl.alpinelinux.org/alpine/edge/testing ostree
+
+COPY --from=builder /go/src/github.com/projectatomic/skopeo/skopeo /usr/bin/skopeo

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,9 @@ binary-local:
 binary-local-static:
 	go build -ldflags "-extldflags \"-static\" -X main.gitCommit=${GIT_COMMIT}" -gcflags "$(GOGCFLAGS)" -tags "$(BUILDTAGS)" -o skopeo ./cmd/skopeo
 
+build-alpine-container:
+	docker build -t projectatomic/skopeo -f Dockerfile.ms .
+
 build-container:
 	docker build ${DOCKER_BUILD_ARGS} -t "$(DOCKER_IMAGE)" .
 


### PR DESCRIPTION
use Docker multi-stage build to create thin Docker image, based on Alpine linux and `skopeo` (compiled on alpine)