### PR TITLE
fixing error checking due to update in make lint

### DIFF
--- a/cmd/skopeo/delete.go
+++ b/cmd/skopeo/delete.go
@@ -24,10 +24,7 @@ func deleteHandler(context *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	if err := ref.DeleteImage(ctx); err != nil {
-		return err
-	}
-	return nil
+	return ref.DeleteImage(ctx)
 }
 
 var deleteCmd = cli.Command{

--- a/cmd/skopeo/layers.go
+++ b/cmd/skopeo/layers.go
@@ -109,10 +109,6 @@ var layersCmd = cli.Command{
 			return err
 		}
 
-		if err := dest.Commit(); err != nil {
-			return err
-		}
-
-		return nil
+		return dest.Commit()
 	},
 }


### PR DESCRIPTION
make lint is complaining for cases where the error returned is checked
for err != nil, and then returned anyways.

Needed for https://github.com/containers/image/pull/333

Signed-off-by: umohnani8 <umohnani@redhat.com>