### PR TITLE
DO NOT MERGE (test): Simplify error checking to appease new golint

### DIFF
--- a/cmd/skopeo/delete.go
+++ b/cmd/skopeo/delete.go
@@ -24,10 +24,7 @@ func deleteHandler(context *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	if err := ref.DeleteImage(ctx); err != nil {
-		return err
-	}
-	return nil
+	return ref.DeleteImage(ctx)
 }
 
 var deleteCmd = cli.Command{

--- a/cmd/skopeo/layers.go
+++ b/cmd/skopeo/layers.go
@@ -109,10 +109,6 @@ var layersCmd = cli.Command{
 			return err
 		}
 
-		if err := dest.Commit(); err != nil {
-			return err
-		}
-
-		return nil
+		return dest.Commit()
 	},
 }


### PR DESCRIPTION
```
cmd/skopeo/delete.go:27:2: redundant if ...; err != nil check, just return error instead.
cmd/skopeo/layers.go:112:3: redundant if ...; err != nil check, just return error instead.
```