### PR TITLE
Create smaller testing containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ RUN dnf -y update && dnf install -y make git golang golang-github-cpuguy83-go-md
 	ostree-devel \
 	gnupg \
 	# OpenShift deps
-	which tar wget hostname util-linux bsdtar socat ethtool device-mapper iptables tree findutils nmap-ncat e2fsprogs xfsprogs lsof docker iproute
+	which tar wget hostname util-linux bsdtar socat ethtool device-mapper iptables tree findutils nmap-ncat e2fsprogs xfsprogs lsof docker iproute \
+	&& dnf clean all
 
 # Install two versions of the registry. The first is an older version that
 # only supports schema1 manifests. The second is a newer version that supports

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,9 @@ RUN dnf -y update && dnf install -y make git golang golang-github-cpuguy83-go-md
 # only supports schema1 manifests. The second is a newer version that supports
 # both. This allows integration-cli tests to cover push/pull with both schema1
 # and schema2 manifests.
-ENV REGISTRY_COMMIT_SCHEMA1 ec87e9b6971d831f0eff752ddb54fb64693e51cd
-ENV REGISTRY_COMMIT 47a064d4195a9b56133891bbb13620c3ac83a827
 RUN set -x \
+	&& REGISTRY_COMMIT_SCHEMA1=ec87e9b6971d831f0eff752ddb54fb64693e51cd \
+	&& REGISTRY_COMMIT=47a064d4195a9b56133891bbb13620c3ac83a827 \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/distribution.git "$GOPATH/src/github.com/docker/distribution" \
 	&& (cd "$GOPATH/src/github.com/docker/distribution" && git checkout -q "$REGISTRY_COMMIT") \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,9 @@ RUN dnf -y update && dnf install -y make git golang golang-github-cpuguy83-go-md
 	# gpgme bindings deps
 	libassuan-devel gpgme-devel \
 	ostree-devel \
-	gnupg
+	gnupg \
+	# OpenShift deps
+	which tar wget hostname util-linux bsdtar socat ethtool device-mapper iptables tree findutils nmap-ncat e2fsprogs xfsprogs lsof docker iproute
 
 # Install two versions of the registry. The first is an older version that
 # only supports schema1 manifests. The second is a newer version that supports
@@ -27,7 +29,6 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 RUN set -x \
-	&& yum install -y which git tar wget hostname util-linux bsdtar socat ethtool device-mapper iptables tree findutils nmap-ncat e2fsprogs xfsprogs lsof docker iproute \
 	&& export GOPATH=$(mktemp -d) \
 	&& git clone --depth 1 -b v1.5.0-alpha.3 git://github.com/openshift/origin "$GOPATH/src/github.com/openshift/origin" \
 	&& (cd "$GOPATH/src/github.com/openshift/origin" && make clean build && make all WHAT=cmd/dockerregistry) \

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN set -x \
 	&& (cd "$GOPATH/src/github.com/openshift/origin" && make clean build && make all WHAT=cmd/dockerregistry) \
 	&& cp -a "$GOPATH/src/github.com/openshift/origin/_output/local/bin/linux"/*/* /usr/local/bin \
 	&& cp "$GOPATH/src/github.com/openshift/origin/images/dockerregistry/config.yml" /atomic-registry-config.yml \
+	&& rm -rf "$GOPATH" \
 	&& mkdir /registry
 
 ENV GOPATH /usr/share/gocode:/go


### PR DESCRIPTION
Four small changes to reduce the size of the `skopeo-dev` containers.

Looking at `docker history`, the RPM installation step is now 605 MB instead of 611 MB, while installing many more packages; and the OpenShift build step is 456 MB instead of 1.82 GB.  Overall, the container size is decreased from 2.78 GB to 1.41 GB, almost by half.

See the individual commit messages for details.