### PR TITLE
copy: add shared blob directory support for OCI sources/destinations

### DIFF
--- a/cmd/skopeo/copy.go
+++ b/cmd/skopeo/copy.go
@@ -121,5 +121,15 @@ var copyCmd = cli.Command{
 			Value: "",
 			Usage: "`DIRECTORY` to use for OSTree temporary files",
 		},
+		cli.StringFlag{
+			Name:  "src-shared-blob-dir",
+			Value: "",
+			Usage: "`DIRECTORY` to use to fetch retrieved blobs (OCI layout sources only)",
+		},
+		cli.StringFlag{
+			Name:  "dest-shared-blob-dir",
+			Value: "",
+			Usage: "`DIRECTORY` to use to store retrieved blobs (OCI layout destinations only)",
+		},
 	},
 }

--- a/cmd/skopeo/utils.go
+++ b/cmd/skopeo/utils.go
@@ -17,6 +17,7 @@ func contextFromGlobalOptions(c *cli.Context, flagPrefix string) (*types.SystemC
 		// them if per subcommand flags are provided (see below).
 		DockerInsecureSkipTLSVerify: !c.GlobalBoolT("tls-verify"),
 		OSTreeTmpDirPath:            c.String(flagPrefix + "ostree-tmp-dir"),
+		OCISharedBlobDirPath:        c.String(flagPrefix + "shared-blob-dir"),
 	}
 	if c.IsSet(flagPrefix + "tls-verify") {
 		ctx.DockerInsecureSkipTLSVerify = !c.BoolT(flagPrefix + "tls-verify")

--- a/vendor/github.com/containers/image/oci/layout/oci_transport.go
+++ b/vendor/github.com/containers/image/oci/layout/oci_transport.go
@@ -261,7 +261,7 @@ func (ref ociReference) NewImageSource(ctx *types.SystemContext) (types.ImageSou
 // NewImageDestination returns a types.ImageDestination for this reference.
 // The caller must call .Close() on the returned ImageDestination.
 func (ref ociReference) NewImageDestination(ctx *types.SystemContext) (types.ImageDestination, error) {
-	return newImageDestination(ref)
+	return newImageDestination(ctx, ref)
 }
 
 // DeleteImage deletes the named image from the registry, if supported.
@@ -280,9 +280,13 @@ func (ref ociReference) indexPath() string {
 }
 
 // blobPath returns a path for a blob within a directory using OCI image-layout conventions.
-func (ref ociReference) blobPath(digest digest.Digest) (string, error) {
+func (ref ociReference) blobPath(digest digest.Digest, sharedBlobDir string) (string, error) {
 	if err := digest.Validate(); err != nil {
 		return "", errors.Wrapf(err, "unexpected digest reference %s", digest)
 	}
-	return filepath.Join(ref.dir, "blobs", digest.Algorithm().String(), digest.Hex()), nil
+	blobDir := filepath.Join(ref.dir, "blobs")
+	if sharedBlobDir != "" {
+		blobDir = sharedBlobDir
+	}
+	return filepath.Join(blobDir, digest.Algorithm().String(), digest.Hex()), nil
 }

--- a/vendor/github.com/containers/image/types/types.go
+++ b/vendor/github.com/containers/image/types/types.go
@@ -316,6 +316,8 @@ type SystemContext struct {
 	OCICertPath string
 	// Allow downloading OCI image layers over HTTP, or HTTPS with failed TLS verification. Note that this does not affect other TLS connections.
 	OCIInsecureSkipTLSVerify bool
+	// If not "", use a shared directory for storing blobs rather than within OCI layouts
+	OCISharedBlobDirPath string
 
 	// === docker.Transport overrides ===
 	// If not "", a directory containing a CA certificate (ending with ".crt"),


### PR DESCRIPTION
Following on from containers/image#369, this adds command-line flags to `skopeo copy` which allow users to use a shared directory for blobs when working with OCI layouts.

@runcom this patch is nice and tiny, but is there a better way to scope flags to specific source/dest types?