### PR TITLE
README.md: Fix example of skopeo copy command

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ local directories, and local OCI-layout directories:
 ```sh
 $ skopeo copy docker://busybox:1-glibc atomic:myns/unsigned:streaming
 $ skopeo copy docker://busybox:latest dir:existingemptydirectory
-$ skopeo copy docker://busybox:latest oci:busybox_ocilayout
+$ skopeo copy docker://busybox:latest oci:busybox_ocilayout:latest
 ```
 
 Deleting images


### PR DESCRIPTION
In README.md, there is an example of skopeo copy command to download an
image in OCI format, but the current code returns an error:

skopeo copy docker://busybox:latest oci:busybox_ocilayout
FATA[0000] Error initializing destination oci:tmp:: cannot save image with empty image.ref.name

If we add a tag after the oci directory, the problem is gone:
skopeo copy docker://busybox:latest oci:busybox_ocilayout:latest

Fixes: #446

Signed-off-by: Marcos Paulo de Souza <marcos.souza.org@gmail.com>