### PR TITLE
Add manifest type conversion to skopeo copy

### DIFF
--- a/cmd/skopeo/utils.go
+++ b/cmd/skopeo/utils.go
@@ -18,6 +18,7 @@ func contextFromGlobalOptions(c *cli.Context, flagPrefix string) (*types.SystemC
 		DockerInsecureSkipTLSVerify: !c.GlobalBoolT("tls-verify"),
 		OSTreeTmpDirPath:            c.String(flagPrefix + "ostree-tmp-dir"),
 		OCISharedBlobDirPath:        c.String(flagPrefix + "shared-blob-dir"),
+		DirForceCompress:            c.Bool(flagPrefix + "compress"),
 	}
 	if c.IsSet(flagPrefix + "tls-verify") {
 		ctx.DockerInsecureSkipTLSVerify = !c.BoolT(flagPrefix + "tls-verify")

--- a/completions/bash/skopeo
+++ b/completions/bash/skopeo
@@ -20,20 +20,24 @@ _complete_() {
 }
 
 _skopeo_copy() {
-     local options_with_args="
-	--sign-by
-	--src-creds --screds
-	--src-cert-dir
-	--src-tls-verify
-	--dest-creds --dcreds
-	--dest-cert-dir
-	--dest-ostree-tmp-dir
-	--dest-tls-verify
-     "
-     local boolean_options="
-	--remove-signatures
-     "
-     _complete_ "$options_with_args" "$boolean_options"
+    local options_with_args="
+    --format -f
+    --sign-by
+    --src-creds --screds
+    --src-cert-dir
+    --src-tls-verify
+    --dest-creds --dcreds
+    --dest-cert-dir
+    --dest-ostree-tmp-dir
+    --dest-tls-verify
+    "
+
+    local boolean_options="
+    --dest-compress
+    --remove-signatures
+    "
+
+    _complete_ "$options_with_args" "$boolean_options"
 }
 
 _skopeo_inspect() {

--- a/docs/skopeo.1.md
+++ b/docs/skopeo.1.md
@@ -60,11 +60,15 @@ Uses the system's trust policy to validate images, rejects images not trusted by
 
   _destination-image_ use the "image name" format described above
 
+  **--format, -f** _manifest-type_ Manifest type (oci, v2s1, or v2s2) to use when saving image to directory using the 'dir:' transport (default is manifest type of source)
+
   **--remove-signatures** do not copy signatures, if any, from _source-image_. Necessary when copying a signed image to a destination which does not support signatures.
 
   **--sign-by=**_key-id_ add a signature using that key ID for an image name corresponding to _destination-image_
 
   **--src-creds** _username[:password]_ for accessing the source registry
+
+  **--dest-compress** _bool-value_ Compress tarball image layers when saving to directory using the 'dir' transport. (default is same compression type as source)
 
   **--dest-creds** _username[:password]_ for accessing the destination registry
 

--- a/vendor.conf
+++ b/vendor.conf
@@ -1,5 +1,5 @@
 github.com/urfave/cli v1.17.0
-github.com/containers/image master
+github.com/containers/image f950aa3529148eb0dea90888c24b6682da641b13
 github.com/opencontainers/go-digest master
 gopkg.in/cheggaaa/pb.v1 ad4efe000aa550bb54918c06ebbadc0ff17687b9 https://github.com/cheggaaa/pb
 github.com/containers/storage master

--- a/vendor/github.com/containers/image/copy/copy.go
+++ b/vendor/github.com/containers/image/copy/copy.go
@@ -12,8 +12,6 @@ import (
 	"strings"
 	"time"
 
-	pb "gopkg.in/cheggaaa/pb.v1"
-
 	"github.com/containers/image/image"
 	"github.com/containers/image/pkg/compression"
 	"github.com/containers/image/signature"
@@ -22,6 +20,7 @@ import (
 	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	pb "gopkg.in/cheggaaa/pb.v1"
 )
 
 type digestingReader struct {
@@ -95,6 +94,8 @@ type Options struct {
 	DestinationCtx   *types.SystemContext
 	ProgressInterval time.Duration                 // time to wait between reports to signal the progress channel
 	Progress         chan types.ProgressProperties // Reported to when ProgressInterval has arrived for a single artifact+offset.
+	// manifest MIME type of image set by user. "" is default and means use the autodetection to the the manifest MIME type
+	ForceManifestMIMEType string
 }
 
 // Image copies image from srcRef to destRef, using policyContext to validate
@@ -193,7 +194,7 @@ func Image(policyContext *signature.PolicyContext, destRef, srcRef types.ImageRe
 
 	// We compute preferredManifestMIMEType only to show it in error messages.
 	// Without having to add this context in an error message, we would be happy enough to know only that no conversion is needed.
-	preferredManifestMIMEType, otherManifestMIMETypeCandidates, err := determineManifestConversion(&manifestUpdates, src, dest.SupportedManifestMIMETypes(), canModifyManifest)
+	preferredManifestMIMEType, otherManifestMIMETypeCandidates, err := determineManifestConversion(&manifestUpdates, src, dest.SupportedManifestMIMETypes(), canModifyManifest, options.ForceManifestMIMEType)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/containers/image/copy/manifest.go
+++ b/vendor/github.com/containers/image/copy/manifest.go
@@ -41,10 +41,14 @@ func (os *orderedSet) append(s string) {
 // Note that the conversion will only happen later, through src.UpdatedImage
 // Returns the preferred manifest MIME type (whether we are converting to it or using it unmodified),
 // and a list of other possible alternatives, in order.
-func determineManifestConversion(manifestUpdates *types.ManifestUpdateOptions, src types.Image, destSupportedManifestMIMETypes []string, canModifyManifest bool) (string, []string, error) {
+func determineManifestConversion(manifestUpdates *types.ManifestUpdateOptions, src types.Image, destSupportedManifestMIMETypes []string, canModifyManifest bool, forceManifestMIMEType string) (string, []string, error) {
 	_, srcType, err := src.Manifest()
 	if err != nil { // This should have been cached?!
 		return "", nil, errors.Wrap(err, "Error reading manifest")
+	}
+
+	if forceManifestMIMEType != "" {
+		destSupportedManifestMIMETypes = []string{forceManifestMIMEType}
 	}
 
 	if len(destSupportedManifestMIMETypes) == 0 {

--- a/vendor/github.com/containers/image/directory/directory_transport.go
+++ b/vendor/github.com/containers/image/directory/directory_transport.go
@@ -152,7 +152,11 @@ func (ref dirReference) NewImageSource(ctx *types.SystemContext) (types.ImageSou
 // NewImageDestination returns a types.ImageDestination for this reference.
 // The caller must call .Close() on the returned ImageDestination.
 func (ref dirReference) NewImageDestination(ctx *types.SystemContext) (types.ImageDestination, error) {
-	return newImageDestination(ref), nil
+	compress := false
+	if ctx != nil {
+		compress = ctx.DirForceCompress
+	}
+	return newImageDestination(ref, compress)
 }
 
 // DeleteImage deletes the named image from the registry, if supported.
@@ -174,4 +178,9 @@ func (ref dirReference) layerPath(digest digest.Digest) string {
 // signaturePath returns a path for a signature within a directory using our conventions.
 func (ref dirReference) signaturePath(index int) string {
 	return filepath.Join(ref.path, fmt.Sprintf("signature-%d", index+1))
+}
+
+// versionPath returns a path for the version file within a directory using our conventions.
+func (ref dirReference) versionPath() string {
+	return filepath.Join(ref.path, "version")
 }

--- a/vendor/github.com/containers/image/docker/docker_image_dest.go
+++ b/vendor/github.com/containers/image/docker/docker_image_dest.go
@@ -236,7 +236,7 @@ func (d *dockerImageDestination) PutManifest(m []byte) error {
 		return err
 	}
 	defer res.Body.Close()
-	if res.StatusCode != http.StatusCreated {
+	if !successStatus(res.StatusCode) {
 		err = errors.Wrapf(client.HandleErrorResponse(res), "Error uploading manifest to %s", path)
 		if isManifestInvalidError(errors.Cause(err)) {
 			err = types.ManifestTypeRejectedError{Err: err}
@@ -244,6 +244,12 @@ func (d *dockerImageDestination) PutManifest(m []byte) error {
 		return err
 	}
 	return nil
+}
+
+// successStatus returns true if the argument is a successful HTTP response
+// code (in the range 200 - 399 inclusive).
+func successStatus(status int) bool {
+	return status >= 200 && status <= 399
 }
 
 // isManifestInvalidError returns true iff err from client.HandleErrorReponse is a “manifest invalid” error.

--- a/vendor/github.com/containers/image/types/types.go
+++ b/vendor/github.com/containers/image/types/types.go
@@ -349,6 +349,10 @@ type SystemContext struct {
 	DockerDaemonHost string
 	// Used to skip TLS verification, off by default. To take effect DockerDaemonCertPath needs to be specified as well.
 	DockerDaemonInsecureSkipTLSVerify bool
+
+	// === dir.Transport overrides ===
+	// DirForceCompress compresses the image layers if set to true
+	DirForceCompress bool
 }
 
 // ProgressProperties is used to pass information from the copy code to a monitor which


### PR DESCRIPTION
Add manifest type conversion to skopeo with dir transport

User can select from 3 manifest types: oci, v2s1, or v2s2
Adds option to compress blobs when saving to the directory using the dir transport
e.g skopeo copy --format v2s1 --compress-blobs docker-archive:alp.tar dir:my-directory

Addresses issue https://github.com/projectatomic/skopeo/issues/361

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>
