### PR TITLE
vendor: bump containers/image and containers/image

### DIFF
--- a/vendor/github.com/containers/image/directory/directory_dest.go
+++ b/vendor/github.com/containers/image/directory/directory_dest.go
@@ -70,7 +70,7 @@ func newImageDestination(ref dirReference, compress bool) (types.ImageDestinatio
 		}
 	}
 	// create version file
-	err = ioutil.WriteFile(d.ref.versionPath(), []byte(version), 0755)
+	err = ioutil.WriteFile(d.ref.versionPath(), []byte(version), 0644)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error creating version file %q", d.ref.versionPath())
 	}

--- a/vendor/github.com/containers/image/docker/docker_image_dest.go
+++ b/vendor/github.com/containers/image/docker/docker_image_dest.go
@@ -131,7 +131,7 @@ func (d *dockerImageDestination) PutBlob(stream io.Reader, inputInfo types.BlobI
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusAccepted {
 		logrus.Debugf("Error initiating layer upload, response %#v", *res)
-		return types.BlobInfo{}, errors.Errorf("Error initiating layer upload to %s, status %d", uploadPath, res.StatusCode)
+		return types.BlobInfo{}, errors.Wrapf(client.HandleErrorResponse(res), "Error initiating layer upload to %s", uploadPath)
 	}
 	uploadLocation, err := res.Location()
 	if err != nil {
@@ -167,7 +167,7 @@ func (d *dockerImageDestination) PutBlob(stream io.Reader, inputInfo types.BlobI
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusCreated {
 		logrus.Debugf("Error uploading layer, response %#v", *res)
-		return types.BlobInfo{}, errors.Errorf("Error uploading layer to %s, status %d", uploadLocation, res.StatusCode)
+		return types.BlobInfo{}, errors.Wrapf(client.HandleErrorResponse(res), "Error uploading layer to %s", uploadLocation)
 	}
 
 	logrus.Debugf("Upload of layer %s complete", computedDigest)
@@ -447,7 +447,7 @@ sigExists:
 				logrus.Debugf("Error body %s", string(body))
 			}
 			logrus.Debugf("Error uploading signature, status %d, %#v", res.StatusCode, res)
-			return errors.Errorf("Error uploading signature to %s, status %d", path, res.StatusCode)
+			return errors.Wrapf(client.HandleErrorResponse(res), "Error uploading signature to %s", path)
 		}
 	}
 

--- a/vendor/github.com/containers/image/image/oci.go
+++ b/vendor/github.com/containers/image/image/oci.go
@@ -149,6 +149,16 @@ func (m *manifestOCI1) UpdatedImage(options types.ManifestUpdateOptions) (types.
 
 	switch options.ManifestMIMEType {
 	case "": // No conversion, OK
+	case manifest.DockerV2Schema1MediaType, manifest.DockerV2Schema1SignedMediaType:
+		// We can't directly convert to V1, but we can transitively convert via a V2 image
+		m2, err := copy.convertToManifestSchema2()
+		if err != nil {
+			return nil, err
+		}
+		return m2.UpdatedImage(types.ManifestUpdateOptions{
+			ManifestMIMEType: options.ManifestMIMEType,
+			InformationOnly:  options.InformationOnly,
+		})
 	case manifest.DockerV2Schema2MediaType:
 		return copy.convertToManifestSchema2()
 	default:

--- a/vendor/github.com/containers/image/tarball/tarball_reference.go
+++ b/vendor/github.com/containers/image/tarball/tarball_reference.go
@@ -89,5 +89,5 @@ func (r *tarballReference) DeleteImage(ctx *types.SystemContext) error {
 }
 
 func (r *tarballReference) NewImageDestination(ctx *types.SystemContext) (types.ImageDestination, error) {
-	return nil, fmt.Errorf("destination not implemented yet")
+	return nil, fmt.Errorf(`"tarball:" locations can only be read from, not written to`)
 }

--- a/vendor/github.com/containers/storage/drivers/overlay/overlay.go
+++ b/vendor/github.com/containers/storage/drivers/overlay/overlay.go
@@ -245,9 +245,7 @@ func supportsOverlay(home string, homeMagic graphdriver.FsMagic, rootUID, rootGI
 			return false, err
 		}
 		if !supportsDType {
-			logrus.Warn(overlayutils.ErrDTypeNotSupported("overlay", backingFs))
-			// TODO: Will make fatal when CRI-O Has AMI built on RHEL7.4
-			// return nil, overlayutils.ErrDTypeNotSupported("overlay", backingFs)
+			return false, overlayutils.ErrDTypeNotSupported("overlay", backingFs)
 		}
 
 		// Try a test mount in the specific location we're looking at using.


### PR DESCRIPTION
Update containers/image and containers/storage to the current master
revisions.

So to inherit all the fixes in the ostree backend.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>