### PR TITLE
Bump 0.1.28

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.1.28"
+const Version = "0.1.29-dev"

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the build.
-const Version = "0.1.28-dev"
+const Version = "0.1.28"


### PR DESCRIPTION
Releasing a new version mainly for the selinux fixes for system containers. Will tag https://github.com/projectatomic/skopeo/commit/0270e5694c9adf6eabfa3ab1f2980b8b62deb4b7 as `v0.1.28`.

@mtrmac @giuseppe @rhatdan PTAL