### PR TITLE
Support host configuration for docker-daemon sources and destinations

### DIFF
--- a/cmd/skopeo/copy.go
+++ b/cmd/skopeo/copy.go
@@ -122,20 +122,20 @@ var copyCmd = cli.Command{
 		cli.StringFlag{
 			Name:  "src-cert-dir",
 			Value: "",
-			Usage: "use certificates at `PATH` (*.crt, *.cert, *.key) to connect to the source registry",
+			Usage: "use certificates at `PATH` (*.crt, *.cert, *.key) to connect to the source registry or daemon",
 		},
 		cli.BoolTFlag{
 			Name:  "src-tls-verify",
-			Usage: "require HTTPS and verify certificates when talking to the container source registry (defaults to true)",
+			Usage: "require HTTPS and verify certificates when talking to the container source registry or daemon (defaults to true)",
 		},
 		cli.StringFlag{
 			Name:  "dest-cert-dir",
 			Value: "",
-			Usage: "use certificates at `PATH` (*.crt, *.cert, *.key) to connect to the destination registry",
+			Usage: "use certificates at `PATH` (*.crt, *.cert, *.key) to connect to the destination registry or daemon",
 		},
 		cli.BoolTFlag{
 			Name:  "dest-tls-verify",
-			Usage: "require HTTPS and verify certificates when talking to the container destination registry (defaults to true)",
+			Usage: "require HTTPS and verify certificates when talking to the container destination registry or daemon (defaults to true)",
 		},
 		cli.StringFlag{
 			Name:  "dest-ostree-tmp-dir",
@@ -159,6 +159,16 @@ var copyCmd = cli.Command{
 		cli.BoolFlag{
 			Name:  "dest-compress",
 			Usage: "Compress tarball image layers when saving to directory using the 'dir' transport. (default is same compression type as source)",
+		},
+		cli.StringFlag{
+			Name:  "src-daemon-host",
+			Value: "",
+			Usage: "use docker daemon host at `HOST` (docker-daemon sources only)",
+		},
+		cli.StringFlag{
+			Name:  "dest-daemon-host",
+			Value: "",
+			Usage: "use docker daemon host at `HOST` (docker-daemon destinations only)",
 		},
 	},
 }

--- a/cmd/skopeo/utils.go
+++ b/cmd/skopeo/utils.go
@@ -17,11 +17,14 @@ func contextFromGlobalOptions(c *cli.Context, flagPrefix string) (*types.SystemC
 		DockerCertPath:     c.String(flagPrefix + "cert-dir"),
 		// DEPRECATED: keep this here for backward compatibility, but override
 		// them if per subcommand flags are provided (see below).
-		DockerInsecureSkipTLSVerify: !c.GlobalBoolT("tls-verify"),
-		OSTreeTmpDirPath:            c.String(flagPrefix + "ostree-tmp-dir"),
-		OCISharedBlobDirPath:        c.String(flagPrefix + "shared-blob-dir"),
-		DirForceCompress:            c.Bool(flagPrefix + "compress"),
-		AuthFilePath:                c.String("authfile"),
+		DockerInsecureSkipTLSVerify:       !c.GlobalBoolT("tls-verify"),
+		OSTreeTmpDirPath:                  c.String(flagPrefix + "ostree-tmp-dir"),
+		OCISharedBlobDirPath:              c.String(flagPrefix + "shared-blob-dir"),
+		DirForceCompress:                  c.Bool(flagPrefix + "compress"),
+		AuthFilePath:                      c.String("authfile"),
+		DockerDaemonHost:                  c.String(flagPrefix + "daemon-host"),
+		DockerDaemonCertPath:              c.String(flagPrefix + "cert-dir"),
+		DockerDaemonInsecureSkipTLSVerify: !c.BoolT(flagPrefix + "tls-verify"),
 	}
 	if c.IsSet(flagPrefix + "tls-verify") {
 		ctx.DockerInsecureSkipTLSVerify = !c.BoolT(flagPrefix + "tls-verify")

--- a/completions/bash/skopeo
+++ b/completions/bash/skopeo
@@ -31,6 +31,8 @@ _skopeo_copy() {
     --dest-cert-dir
     --dest-ostree-tmp-dir
     --dest-tls-verify
+    --src-daemon-host
+    --dest-daemon-host
     "
 
     local boolean_options="

--- a/docs/skopeo.1.md
+++ b/docs/skopeo.1.md
@@ -93,15 +93,19 @@ Uses the system's trust policy to validate images, rejects images not trusted by
 
   **--dest-creds** _username[:password]_ for accessing the destination registry
 
-  **--src-cert-dir** _path_ Use certificates at _path_ (*.crt, *.cert, *.key) to connect to the source registry
+  **--src-cert-dir** _path_ Use certificates at _path_ (*.crt, *.cert, *.key) to connect to the source registry or daemon
 
-  **--src-tls-verify** _bool-value_ Require HTTPS and verify certificates when talking to container source registry (defaults to true)
+  **--src-tls-verify** _bool-value_ Require HTTPS and verify certificates when talking to container source registry or daemon (defaults to true)
 
-  **--dest-cert-dir** _path_ Use certificates at _path_ (*.crt, *.cert, *.key) to connect to the destination registry
+  **--dest-cert-dir** _path_ Use certificates at _path_ (*.crt, *.cert, *.key) to connect to the destination registry or daemon
 
   **--dest-ostree-tmp-dir** _path_ Directory to use for OSTree temporary files.
 
-  **--dest-tls-verify** _bool-value_ Require HTTPS and verify certificates when talking to container destination registry (defaults to true)
+  **--dest-tls-verify** _bool-value_ Require HTTPS and verify certificates when talking to container destination registry or daemon (defaults to true)
+
+  **--src-daemon-host** _host_ Copy from docker daemon at _host_. If _host_ starts with `tcp://`, HTTPS is enabled by default. To use plain HTTP, use the form `http://` (default is `unix:///var/run/docker.sock`).
+
+  **--dest-daemon-host** _host_ Copy to docker daemon at _host_. If _host_ starts with `tcp://`, HTTPS is enabled by default. To use plain HTTP, use the form `http://` (default is `unix:///var/run/docker.sock`).
 
 Existing signatures, if any, are preserved as well.
 


### PR DESCRIPTION
This PR adds CLI support for overriding the default docker daemon host when using the
`docker-daemon` transport.

See also containers/image#434

Fixes #244

Signed-off-by: Justin Lewis Salmon <justin.lewis.salmon@gmail.com>