### PR TITLE
skopeo-copy: docker-archive: multitag support

### DIFF
--- a/vendor/github.com/containers/image/docker/archive/dest.go
+++ b/vendor/github.com/containers/image/docker/archive/dest.go
@@ -16,7 +16,7 @@ type archiveImageDestination struct {
 	writer               io.Closer
 }
 
-func newImageDestination(ref archiveReference) (types.ImageDestination, error) {
+func newImageDestination(sys *types.SystemContext, ref archiveReference) (types.ImageDestination, error) {
 	if ref.destinationRef == nil {
 		return nil, errors.Errorf("docker-archive: destination reference not supplied (must be of form <path>:<reference:tag>)")
 	}
@@ -40,8 +40,12 @@ func newImageDestination(ref archiveReference) (types.ImageDestination, error) {
 		return nil, errors.New("docker-archive doesn't support modifying existing images")
 	}
 
+	tarDest := tarfile.NewDestination(fh, ref.destinationRef)
+	if sys != nil && sys.DockerArchiveAdditionalTags != nil {
+		tarDest.AddRepoTags(sys.DockerArchiveAdditionalTags)
+	}
 	return &archiveImageDestination{
-		Destination: tarfile.NewDestination(fh, ref.destinationRef),
+		Destination: tarDest,
 		ref:         ref,
 		writer:      fh,
 	}, nil

--- a/vendor/github.com/containers/image/docker/archive/transport.go
+++ b/vendor/github.com/containers/image/docker/archive/transport.go
@@ -148,7 +148,7 @@ func (ref archiveReference) NewImageSource(ctx context.Context, sys *types.Syste
 // NewImageDestination returns a types.ImageDestination for this reference.
 // The caller must call .Close() on the returned ImageDestination.
 func (ref archiveReference) NewImageDestination(ctx context.Context, sys *types.SystemContext) (types.ImageDestination, error) {
-	return newImageDestination(ref)
+	return newImageDestination(sys, ref)
 }
 
 // DeleteImage deletes the named image from the registry, if supported.

--- a/vendor/github.com/containers/image/internal/tmpdir/tmpdir.go
+++ b/vendor/github.com/containers/image/internal/tmpdir/tmpdir.go
@@ -5,6 +5,16 @@ import (
 	"runtime"
 )
 
+// unixTempDirForBigFiles is the directory path to store big files on non Windows systems.
+// You can override this at build time with
+// -ldflags '-X github.com/containers/image/internal/tmpdir.unixTempDirForBigFiles=$your_path'
+var unixTempDirForBigFiles = builtinUnixTempDirForBigFiles
+
+// builtinUnixTempDirForBigFiles is the directory path to store big files.
+// Do not use the system default of os.TempDir(), usually /tmp, because with systemd it could be a tmpfs.
+// DO NOT change this, instead see unixTempDirForBigFiles above.
+const builtinUnixTempDirForBigFiles = "/var/tmp"
+
 // TemporaryDirectoryForBigFiles returns a directory for temporary (big) files.
 // On non Windows systems it avoids the use of os.TempDir(), because the default temporary directory usually falls under /tmp
 // which on systemd based systems could be the unsuitable tmpfs filesystem.
@@ -13,7 +23,7 @@ func TemporaryDirectoryForBigFiles() string {
 	if runtime.GOOS == "windows" {
 		temporaryDirectoryForBigFiles = os.TempDir()
 	} else {
-		temporaryDirectoryForBigFiles = "/var/tmp"
+		temporaryDirectoryForBigFiles = unixTempDirForBigFiles
 	}
 	return temporaryDirectoryForBigFiles
 }

--- a/vendor/github.com/containers/image/storage/storage_image.go
+++ b/vendor/github.com/containers/image/storage/storage_image.go
@@ -14,6 +14,7 @@ import (
 	"sync/atomic"
 
 	"github.com/containers/image/image"
+	"github.com/containers/image/internal/tmpdir"
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
 	"github.com/containers/storage"
@@ -24,8 +25,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
-
-const temporaryDirectoryForBigFiles = "/var/tmp" // Do not use the system default of os.TempDir(), usually /tmp, because with systemd it could be a tmpfs.
 
 var (
 	// ErrBlobDigestMismatch is returned when PutBlob() is given a blob
@@ -240,7 +239,7 @@ func (s *storageImageSource) GetSignatures(ctx context.Context, instanceDigest *
 // newImageDestination sets us up to write a new image, caching blobs in a temporary directory until
 // it's time to Commit() the image
 func newImageDestination(imageRef storageReference) (*storageImageDestination, error) {
-	directory, err := ioutil.TempDir(temporaryDirectoryForBigFiles, "storage")
+	directory, err := ioutil.TempDir(tmpdir.TemporaryDirectoryForBigFiles(), "storage")
 	if err != nil {
 		return nil, errors.Wrapf(err, "error creating a temporary directory")
 	}

--- a/vendor/github.com/containers/image/types/types.go
+++ b/vendor/github.com/containers/image/types/types.go
@@ -347,6 +347,9 @@ type SystemContext struct {
 	// If not "", overrides the use of platform.GOOS when choosing an image or verifying OS match.
 	OSChoice string
 
+	// Additional tags when creating or copying a docker-archive.
+	DockerArchiveAdditionalTags []reference.NamedTagged
+
 	// === OCI.Transport overrides ===
 	// If not "", a directory containing a CA certificate (ending with ".crt"),
 	// a client certificate (ending with ".cert") and a client ceritificate key

--- a/vendor/github.com/containers/image/vendor.conf
+++ b/vendor/github.com/containers/image/vendor.conf
@@ -10,11 +10,9 @@ github.com/docker/go-connections 3ede32e2033de7505e6500d6c868c2b9ed9f169d
 github.com/docker/go-units 0dadbb0345b35ec7ef35e228dabb8de89a65bf52
 github.com/docker/libtrust aabc10ec26b754e797f9028f4589c5b7bd90dc20
 github.com/ghodss/yaml 04f313413ffd65ce25f2541bfd2b2ceec5c0908c
-github.com/gorilla/context 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
 github.com/gorilla/mux 94e7d24fd285520f3d12ae998f7fdd6b5393d453
 github.com/imdario/mergo 50d4dbd4eb0e84778abe37cefef140271d96fade
 github.com/mattn/go-runewidth 14207d285c6c197daabb5c9793d63e7af9ab2d50
-github.com/mattn/go-shellwords 005a0944d84452842197c2108bd9168ced206f78
 github.com/mistifyio/go-zfs c0224de804d438efd11ea6e52ada8014537d6062
 github.com/mtrmac/gpgme b2432428689ca58c2b8e8dea9449d3295cf96fc9
 github.com/opencontainers/go-digest aa2ec055abd10d26d539eb630a92241b781ce4bc


### PR DESCRIPTION
Add multitag support when generating docker-archive tarballs via the
newly added '--aditional-tag' option, which can be specified multiple
times to add more than one tag.  All specified tags will be added to the
RepoTags field in the docker-archive's manifest.json file.

This change requires to vendor the latest containers/image with
commit a1a9391830fd08637edbe45133fd0a8a2682ae75.

Signed-off-by: Valentin Rothberg <vrothberg@suse.com>