### PR TITLE
Run (go vet) on all subpackages instead only of changed files

### DIFF
--- a/hack/make/validate-vet
+++ b/hack/make/validate-vet
@@ -1,28 +1,13 @@
 #!/bin/bash
 
-source "$(dirname "$BASH_SOURCE")/.validate"
+errors=$(go vet $(go list -e ./... | grep -v "$SKOPEO_PKG"/vendor))
 
-IFS=$'\n'
-files=( $(validate_diff --diff-filter=ACMR --name-only -- '*.go' | grep -v '^vendor/' || true) )
-unset IFS
-
-errors=()
-for f in "${files[@]}"; do
-	failedVet=$(go vet "$f")
-	if [ "$failedVet" ]; then
-		errors+=( "$failedVet" )
-	fi
-done
-
-
-if [ ${#errors[@]} -eq 0 ]; then
+if [ -z "$errors" ]; then
 	echo 'Congratulations!  All Go source files have been vetted.'
 else
 	{
 		echo "Errors from go vet:"
-		for err in "${errors[@]}"; do
-			echo " - $err"
-		done
+		echo "$errors"
 		echo
 		echo 'Please fix the above errors. You can test via "go vet" and commit the result.'
 		echo


### PR DESCRIPTION
Apparently, it was never documented to use `go vet $somefile.go` (but `go tool vet $somefile.go` was).

go 1.10 seems to do more checks within packages, and `$somefile.go` is interpreted as a package with only that file (even if other files from that package are in the same directory), leading to spurious `"undefined: $symbol"` errors.

So, just run `go vet` on `./...` (explicitly excluding `skopeo/vendor` for the benefit of Go 1.8). We only have three subpackages, so the savings, if any, from running `go vet` only on the modified subpackages would be small.

More importantly, on a toolchain update, `./...` allows us to see the newly detected issues all at once, instead of randomly waiting for a commit that changes one of the affected files for the failure to show up.