### PR TITLE
[DO NOT MERGE] Pick up changes to transports in containers/image

### DIFF
--- a/integration/copy_test.go
+++ b/integration/copy_test.go
@@ -154,7 +154,10 @@ func (s *CopySuite) TestCopySimple(c *check.C) {
 	// docker v2s2 -> OCI image layout without image name
 	ociDest = "busybox-latest-noimage"
 	defer os.RemoveAll(ociDest)
-	assertSkopeoFails(c, ".*Error initializing destination oci:busybox-latest-noimage:: cannot save image with empty reference name.*", "copy", "docker://busybox:latest", "oci:"+ociDest)
+	assertSkopeoSucceeds(c, "", "copy", "docker://busybox:latest", "oci:"+ociDest)
+	_, err = os.Stat(ociDest)
+	c.Assert(err, check.IsNil)
+
 }
 
 // Check whether dir: images in dir1 and dir2 are equal, ignoring schema1 signatures.

--- a/vendor/github.com/containers/image/docker/archive/dest.go
+++ b/vendor/github.com/containers/image/docker/archive/dest.go
@@ -17,10 +17,6 @@ type archiveImageDestination struct {
 }
 
 func newImageDestination(sys *types.SystemContext, ref archiveReference) (types.ImageDestination, error) {
-	if ref.destinationRef == nil {
-		return nil, errors.Errorf("docker-archive: destination reference not supplied (must be of form <path>:<reference:tag>)")
-	}
-
 	// ref.path can be either a pipe or a regular file
 	// in the case of a pipe, we require that we can open it for write
 	// in the case of a regular file, we don't want to overwrite any pre-existing file

--- a/vendor/github.com/containers/image/docker/archive/transport.go
+++ b/vendor/github.com/containers/image/docker/archive/transport.go
@@ -41,7 +41,9 @@ func (t archiveTransport) ValidatePolicyConfigurationScope(scope string) error {
 
 // archiveReference is an ImageReference for Docker images.
 type archiveReference struct {
-	destinationRef reference.NamedTagged // only used for destinations
+	// only used for destinations
+	// archiveReference.destinationRef is optional and can be nil for destinations as well.
+	destinationRef reference.NamedTagged
 	path           string
 }
 

--- a/vendor/github.com/containers/image/oci/layout/oci_dest.go
+++ b/vendor/github.com/containers/image/oci/layout/oci_dest.go
@@ -25,10 +25,6 @@ type ociImageDestination struct {
 
 // newImageDestination returns an ImageDestination for writing to an existing directory.
 func newImageDestination(sys *types.SystemContext, ref ociReference) (types.ImageDestination, error) {
-	if ref.image == "" {
-		return nil, errors.Errorf("cannot save image with empty reference name (syntax must be of form <transport>:<path>:<reference>)")
-	}
-
 	var index *imgspecv1.Index
 	if indexExists(ref) {
 		var err error
@@ -217,13 +213,11 @@ func (d *ociImageDestination) PutManifest(ctx context.Context, m []byte) error {
 		return err
 	}
 
-	if d.ref.image == "" {
-		return errors.Errorf("cannot save image with empyt image.ref.name")
+	if d.ref.image != "" {
+		annotations := make(map[string]string)
+		annotations["org.opencontainers.image.ref.name"] = d.ref.image
+		desc.Annotations = annotations
 	}
-
-	annotations := make(map[string]string)
-	annotations["org.opencontainers.image.ref.name"] = d.ref.image
-	desc.Annotations = annotations
 	desc.Platform = &imgspecv1.Platform{
 		Architecture: runtime.GOARCH,
 		OS:           runtime.GOOS,

--- a/vendor/github.com/containers/image/oci/layout/oci_transport.go
+++ b/vendor/github.com/containers/image/oci/layout/oci_transport.go
@@ -55,7 +55,9 @@ type ociReference struct {
 	// (But in general, we make no attempt to be completely safe against concurrent hostile filesystem modifications.)
 	dir         string // As specified by the user. May be relative, contain symlinks, etc.
 	resolvedDir string // Absolute path with no symlinks, at least at the time of its creation. Primarily used for policy namespaces.
-	image       string // If image=="", it means the only image in the index.json is used
+	// If image=="", it means the "only image" in the index.json is used in the case it is a source
+	// for destinations, the image name annotation "image.ref.name" is not added to the index.json
+	image string
 }
 
 // ParseReference converts a string, which should not start with the ImageTransport.Name prefix, into an OCI ImageReference.


### PR DESCRIPTION
docker-archive and oci-archive now allow the image reference
for the destination to be empty.
Update tests for this new change.

Fixes tests for https://github.com/containers/image/pull/458

Signed-off-by: umohnani8 <umohnani@redhat.com>