### PR TITLE
vendor: update containers/image

### DIFF
--- a/vendor/github.com/containers/image/ostree/ostree_dest.go
+++ b/vendor/github.com/containers/image/ostree/ostree_dest.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -394,6 +395,9 @@ func (d *ostreeImageDestination) PutSignatures(ctx context.Context, signatures [
 }
 
 func (d *ostreeImageDestination) Commit(ctx context.Context) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	repo, err := otbuiltin.OpenRepo(d.ref.repo)
 	if err != nil {
 		return err


### PR DESCRIPTION
Needed to pick up this change:

ostree: use the same thread for ostree operations

Since https://github.com/ostreedev/ostree/pull/1555, locking is
enabled by default in OSTree.  Unfortunately it uses thread-private
data and it breaks the Golang bindings.  Force the same thread for the
write operations to the OSTree repository.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>