### PR TITLE
Ensure that we still return 1, and print something to stderr, on (skopeo copy) failure

### DIFF
--- a/cmd/skopeo/copy.go
+++ b/cmd/skopeo/copy.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -33,7 +34,8 @@ func contextsFromGlobalOptions(c *cli.Context) (*types.SystemContext, *types.Sys
 
 func copyHandler(c *cli.Context) error {
 	if len(c.Args()) != 2 {
-		return cli.ShowCommandHelp(c, "copy")
+		cli.ShowCommandHelp(c, "copy")
+		return errors.New("Exactly two arguments expected")
 	}
 
 	policyContext, err := getPolicyContext(c)


### PR DESCRIPTION
https://github.com/projectatomic/skopeo/pull/519 made `skopeo copy` suceed and print nothing to stderr; that could lead to hard-to-diagnose failures in rare corner cases, e.g. shell scripts which do
`skopeo copy $src $dst` (as opposed to the correct `skopeo copy "$src" "$dst"` ) if `$src` and `$dst` are empty due to a previous failure.