### PR TITLE
Makefile: add binary-minimal and binary-static-minimal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,12 @@ LIBDM_BUILD_TAG = $(shell hack/libdm_tag.sh)
 LOCAL_BUILD_TAGS = $(BTRFS_BUILD_TAG) $(LIBDM_BUILD_TAG) $(DARWIN_BUILD_TAG)
 BUILDTAGS += $(LOCAL_BUILD_TAGS)
 
+DOCKER_BUILD_IMAGE := skopeobuildimage
+ifeq ($(DISABLE_CGO), 1)
+	override DOCKER_BUILD_IMAGE = golang:1.10
+	override BUILDTAGS = containers_image_ostree_stub exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_openpgp
+endif
+
 #   make all DEBUG=1
 #     Note: Uses the -N -l go compiler options to disable compiler optimizations
 #           and inlining. Using these build options allows you to subsequently
@@ -64,14 +70,18 @@ all: binary docs
 # Build a docker image (skopeobuild) that has everything we need to build.
 # Then do the build and the output (skopeo) should appear in current dir
 binary: cmd/skopeo
-	docker build ${DOCKER_BUILD_ARGS} -f Dockerfile.build -t skopeobuildimage .
+ifneq ($(DISABLE_CGO), 1)
+	docker build ${DOCKER_BUILD_ARGS} -f Dockerfile.build -t $(DOCKER_BUILD_IMAGE) .
+endif
 	docker run --rm --security-opt label:disable -v $$(pwd):/src/github.com/projectatomic/skopeo \
-		skopeobuildimage make binary-local $(if $(DEBUG),DEBUG=$(DEBUG)) BUILDTAGS='$(BUILDTAGS)'
+		$(DOCKER_BUILD_IMAGE) make binary-local $(if $(DEBUG),DEBUG=$(DEBUG)) BUILDTAGS='$(BUILDTAGS)'
 
 binary-static: cmd/skopeo
-	docker build ${DOCKER_BUILD_ARGS} -f Dockerfile.build -t skopeobuildimage .
+ifneq ($(DISABLE_CGO), 1)
+	docker build ${DOCKER_BUILD_ARGS} -f Dockerfile.build -t $(DOCKER_BUILD_IMAGE) .
+endif
 	docker run --rm --security-opt label:disable -v $$(pwd):/src/github.com/projectatomic/skopeo \
-		skopeobuildimage make binary-local-static $(if $(DEBUG),DEBUG=$(DEBUG)) BUILDTAGS='$(BUILDTAGS)'
+		$(DOCKER_BUILD_IMAGE) make binary-local-static $(if $(DEBUG),DEBUG=$(DEBUG)) BUILDTAGS='$(BUILDTAGS)'
 
 # Build w/o using Docker containers
 binary-local:

--- a/README.md
+++ b/README.md
@@ -191,6 +191,12 @@ Building in a container is simpler, but more restrictive:
 $ make binary # Or (make all) to also build documentation, see below.
 ```
 
+To build a pure-Go static binary (disables ostree, devicemapper, btrfs, and gpgme):
+
+```sh
+$ make binary-static DISABLE_CGO=1
+```
+
 ### Building documentation
 To build the manual you will need go-md2man.
 ```sh


### PR DESCRIPTION
These targets produce a pure-Go binary, without the following features:
* ostree
* devicemapper
* btrfs
* gpgme

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>